### PR TITLE
Query builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "sulu/document-manager",
     "description": "Sulu Document Manager",
     "require": {
-        "doctrine/phpcr-odm": "~1.2",
+        "doctrine/phpcr-odm": "~1.3@dev",
         "symfony/event-dispatcher": "~2.0",
         "symfony-cmf/core-bundle": "~1.2",
         "ocramius/proxy-manager": "~1.0",

--- a/lib/Event/QueryCreateBuilderEvent.php
+++ b/lib/Event/QueryCreateBuilderEvent.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Component\DocumentManager\Event;
 
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
-use Sulu\Component\DocumentManager\Query\QueryBuilder;
 
 class QueryCreateBuilderEvent extends AbstractEvent
 {

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -75,4 +75,12 @@ class Metadata
     {
         $this->phpcrType = $phpcrType;
     }
+
+    /**
+     * @return ReflectionClass
+     */
+    public function getReflection()
+    {
+        return new \ReflectionClass($this->class);
+    }
 }

--- a/lib/Query/ConverterSulu.php
+++ b/lib/Query/ConverterSulu.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Sulu\Component\DocumentManager\Query;
+
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Class which converts a Builder tree to a PHPCR Query.
+ */
+class ConverterSulu extends ConverterPhpcr
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var Metadata[]
+     */
+    protected $documentMetadata = array();
+
+    public function __construct(
+        SessionInterface $session,
+        EventDispatcherInterface $eventDispatcher,
+        MetadataFactoryInterface $metadataFactory
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->qomf = $session->getWorkspace()->getQueryManager()->getQOMFactory();
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * Returns an ODM Query object from the given ODM (query) Builder.
+     *
+     * Dispatches the From, Select, Where and OrderBy nodes. Each of these
+     * "root" nodes append or set PHPCR QOM objects to corresponding properties
+     * in this class, which are subsequently used to create a PHPCR QOM object which
+     * is embedded in an ODM Query object.
+     *
+     * @param QueryBuilder $builder
+     *
+     * @return Query
+     */
+    public function getQuery(QueryBuilder $builder)
+    {
+        $this->documentMetadata = array();
+        $this->sourceDocumentNodes = array();
+        $this->constraint = null;
+
+        $this->locale = $builder->getLocale();
+
+        $from = $builder->getChildrenOfType(
+            QBConstants::NT_FROM
+        );
+
+        if (!$from) {
+            throw new RuntimeException(
+                'No From (source) node in query'
+            );
+        }
+
+        $dispatches = array(
+            QBConstants::NT_FROM,
+            QBConstants::NT_SELECT,
+            QBConstants::NT_WHERE,
+            QBConstants::NT_ORDER_BY,
+        );
+
+        foreach ($dispatches as $dispatchType) {
+            $this->dispatchMany($builder->getChildrenOfType($dispatchType));
+        }
+
+        if (count($this->sourceDocumentNodes) > 1 && null === $builder->getPrimaryAlias()) {
+            throw new InvalidArgumentException(
+                'You must specify a primary alias when selecting from multiple document sources' .
+                'e.g. $qb->from(\'a\') ...'
+            );
+        }
+
+        $this->applySourceConstraints($builder);
+
+        $phpcrQuery = $this->qomf->createQuery(
+            $this->from,
+            $this->constraint,
+            $this->orderings,
+            $this->columns
+        );
+
+        $query = new Query($phpcrQuery, $this->eventDispatcher, $builder->getPrimaryAlias());
+
+        if ($firstResult = $builder->getFirstResult()) {
+            $query->setFirstResult($firstResult);
+        }
+
+        if ($maxResults = $builder->getMaxResults()) {
+            $query->setMaxResults($maxResults);
+        }
+
+        return $query;
+    }
+
+    protected function applySourceConstraints(QueryBuilder $builder)
+    {
+        // for each document source add phpcr:{class,classparents} restrictions
+        foreach ($this->sourceDocumentNodes as $sourceNode) {
+            $phpcrType = $this->documentMetadata[$sourceNode->getAlias()]->getPhpcrType();
+
+            // Jackalope-doctrine-dbal does not support selecting from mixins, and Sulu node types
+            // are currently mixins, so we need to explicitly add the mixin criteria.
+            $odmClassConstraints = $this->qomf->comparison(
+                $this->qomf->propertyValue(
+                    $sourceNode->getAlias(),
+                    'jcr:mixinTypes'
+                ),
+                QOMConstants::JCR_OPERATOR_EQUAL_TO,
+                $this->qomf->literal($phpcrType)
+            );
+
+            if ($this->constraint) {
+                $this->constraint = $this->qomf->andConstraint(
+                    $this->constraint,
+                    $odmClassConstraints
+                );
+            } else {
+                $this->constraint = $odmClassConstraints;
+            }
+        }
+    }
+
+    public function walkSelect(AbstractNode $node)
+    {
+        $columns = array();
+
+        /** @var $property Field */
+        foreach ($node->getChildren() as $property) {
+            list($alias, $phpcrName) = $this->getPhpcrProperty(
+                $property->getAlias(),
+                $property->getField()
+            );
+
+            $column = $this->qomf->column(
+                $alias,
+                $phpcrName,
+                // do we want to support custom column names in ODM?
+                $phpcrName
+            );
+
+            $columns[] = $column;
+        }
+
+        $this->columns = $columns;
+
+        return $this->columns;
+    }
+
+    protected function walkSourceDocument(SourceDocument $node)
+    {
+        $alias = $node->getAlias();
+        $documentFqn = $node->getDocumentFqn();
+
+        $this->sourceDocumentNodes[$alias] = $node;
+
+        if ($this->metadataFactory->hasAlias($documentFqn)) {
+            $meta = $this->metadataFactory->getMetadataForAlias($documentFqn);
+        } else {
+            $meta = $this->metadataFactory->getMetadataForClass($documentFqn);
+        }
+
+        $this->documentMetadata[$alias] = $meta;
+
+        // NOTE: Currently we always select from [nt:unstructured] as Sulu node types
+        //       are mixins and jackalope-doctrine-dbal does not support selecting from mixins.
+        //
+        //       See note in getQuery
+        $alias = $this->qomf->selector(
+            $alias,
+            'nt:unstructured'
+        );
+
+        return $alias;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function walkOperandDynamicField(OperandDynamicField $node)
+    {
+        $alias = $node->getAlias();
+        $field = $node->getField();
+
+        $classMeta = $this->documentMetadata[$alias];
+
+        list($alias, $phpcrProperty) = $this->getPhpcrProperty(
+            $alias,
+            $field
+        );
+
+        $op = $this->qomf->propertyValue(
+            $alias,
+            $phpcrProperty
+        );
+
+        return $op;
+    }
+
+    /**
+     * Return the PHPCR property name and alias for the given ODM document
+     * property name and query alias.
+     *
+     * The alias might change if this is a translated field and the strategy
+     * needs to do a join to get in the translation.
+     *
+     * @param string $originalAlias As specified in the query source.
+     * @param string $odmField      Name of ODM document property.
+     *
+     * @return array first element is the real alias to use, second element is
+     *      the property name
+     */
+    protected function getPhpcrProperty($originalAlias, $odmField)
+    {
+        if (!isset($this->documentMetadata[$originalAlias])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown document alias "%s". Known aliases: "%s"',
+                $originalAlias,
+                implode('", "', array_keys($this->documentMetadata))
+            ));
+        }
+
+        return $originalAlias . '.' . $odmField;
+    }
+}

--- a/lib/Subscriber/Phpcr/QuerySubscriber.php
+++ b/lib/Subscriber/Phpcr/QuerySubscriber.php
@@ -11,14 +11,15 @@
 
 namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
 
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use PHPCR\Query\QueryInterface;
-use PHPCR\Query\QueryManagerInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryCreateBuilderEvent;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Query\ConverterSulu;
 use Sulu\Component\DocumentManager\Query\Query;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -39,13 +40,19 @@ class QuerySubscriber implements EventSubscriberInterface
     private $eventDispatcher;
 
     /**
+     * @var ConverterSulu
+     */
+    private $builderConverter;
+
+    /**
      * @param SessionInterface $session
      * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(SessionInterface $session, EventDispatcherInterface $eventDispatcher)
+    public function __construct(SessionInterface $session, EventDispatcherInterface $eventDispatcher, ConverterSulu $builderConverter)
     {
         $this->session = $session;
         $this->eventDispatcher = $eventDispatcher;
+        $this->builderConverter = $builderConverter;
     }
 
     /**
@@ -100,7 +107,9 @@ class QuerySubscriber implements EventSubscriberInterface
      */
     public function handleCreateBuilder(QueryCreateBuilderEvent $event)
     {
-        throw new \Exception('Not implemented');
+        $builder = new QueryBuilder();
+        $builder->setConverter($this->builderConverter);
+        $event->setQueryBuilder($builder);
     }
 
     /**
@@ -117,10 +126,7 @@ class QuerySubscriber implements EventSubscriberInterface
         $event->setResult(new QueryResultCollection($phpcrResult, $this->eventDispatcher, $locale));
     }
 
-    /**
-     * @return QueryManagerInterface
-     */
-    private function getQueryManager()
+    protected function getQueryManager()
     {
         return $this->session->getWorkspace()->getQueryManager();
     }

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -58,6 +58,12 @@
             <argument type="service" id="sulu_document_manager.metadata_factory.base"/>
         </service>
 
+        <service id="sulu_document_manager.query.builder_converter" class="Sulu\Component\DocumentManager\Query\ConverterSulu" public="false">
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+        </service>
+
         <!-- Utilities -->
         <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry">
             <argument type="collection">

--- a/symfony-di/subscribers.xml
+++ b/symfony-di/subscribers.xml
@@ -83,9 +83,10 @@
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session"/>
-            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
-            <tag name="sulu_document_manager.event_subscriber"/>
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument type="service" id="sulu_document_manager.query.builder_converter" />
+            <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.general" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber">

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -22,12 +22,9 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
     protected function initPhpcr()
     {
-        $session = $this->getContainer()->get('doctrine_phpcr.default_session');
-
-        if ($session->getRootNode()->hasNode(self::BASE_NAME)) {
-            $session->removeItem(self::BASE_PATH);
-            $session->save();
-        }
+        $nodeManager = $this->getContainer()->get('sulu_document_manager.node_manager');
+        $nodeManager->purgeWorkspace();
+        $nodeManager->save();
     }
 
     protected function getContainer()

--- a/tests/Functional/DocumentManager/QueryBuilderTest.php
+++ b/tests/Functional/DocumentManager/QueryBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\DocumentManager;
+
+use Sulu\Component\DocumentManager\Tests\Functional\BaseTestCase;
+
+class DocumentManagerTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->initPhpcr();
+    }
+
+    private function createDocument($title)
+    {
+        $manager = $this->getDocumentManager();
+        $document = $manager->create('full');
+
+        $manager->persist($document, 'en', array(
+            'path' => self::BASE_PATH . '/' . $title,
+            'auto_create' => true,
+        ));
+        $manager->flush();
+
+        return $document;
+    }
+
+    /**
+     * Test select from alias.
+     */
+    public function testFromAlias()
+    {
+        $this->createDocument('Hello');
+        $manager = $this->getDocumentManager();
+        $builder = $manager->createQueryBuilder();
+        $query = $builder->from()->document('full', 'p')->end()->getQuery();
+        $results = $query->execute();
+        $this->assertCount(1, $results);
+    }
+
+    /**
+     * Test select from document class.
+     */
+    public function testFromDocumentClass()
+    {
+        $this->createDocument('bar');
+        $manager = $this->getDocumentManager();
+        $builder = $manager->createQueryBuilder();
+        $query = $builder->from()->document('Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument', 'p')->end()->getQuery();
+        $results = $query->execute();
+        $this->assertCount(1, $results);
+    }
+}

--- a/tests/Functional/Model/FullDocument.php
+++ b/tests/Functional/Model/FullDocument.php
@@ -46,6 +46,16 @@ class FullDocument implements
         $this->children = new \ArrayIterator();
     }
 
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -19,6 +19,7 @@ use PHPCR\WorkspaceInterface;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Query\ConverterSulu;
 use Sulu\Component\DocumentManager\Query\Query;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -36,10 +37,12 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
         $this->queryCreateEvent = $this->prophesize(QueryCreateEvent::class);
         $this->queryExecuteEvent = $this->prophesize(QueryExecuteEvent::class);
         $this->query = $this->prophesize(Query::class);
+        $this->converter = $this->prophesize(ConverterSulu::class);
 
         $this->subscriber = new QuerySubscriber(
             $this->session->reveal(),
-            $this->dispatcher->reveal()
+            $this->dispatcher->reveal(),
+            $this->converter->reveal()
         );
 
         $this->session->getWorkspace()->willReturn($this->workspace->reveal());


### PR DESCRIPTION
Initial work for supporting a query builder.

This PR reuses the PHPCR-ODM query builder, and depends on a pull request to make it extensible.

We will need to implement a custom QueryBuilder class in Sulu in order to be able to filter based on structure types.

Example:

``` php
$qb = $documentManager->createQueryBuilder();
$qb->from()->document('page#overview', 'o');
$qb->where()->field('o.#title')->literal('Hello');
$results = $qb->getQuery()->execute();
```
