### PR TITLE
Added path builder

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,7 @@ return Symfony\CS\Config\Config::create()
         '-concat_without_spaces',
         '-phpdoc_indent',
         '-phpdoc_params',
+        '-psr0',
     ))
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()

--- a/bin/testconsole.php
+++ b/bin/testconsole.php
@@ -1,13 +1,12 @@
 <?php
 
 use Sulu\Component\DocumentManager\Tests\Bootstrap;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Application;
 
-require_once(__DIR__ . '/../vendor/autoload.php');
+require_once __DIR__ . '/../vendor/autoload.php';
 
 $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-    'connection' => new \Jackalope\Tools\Console\Helper\DoctrineDbalHelper(Bootstrap::createDbalConnection())
+    'connection' => new \Jackalope\Tools\Console\Helper\DoctrineDbalHelper(Bootstrap::createDbalConnection()),
 ));
 
 $cli = new Application('Sulu Document Manager Test CLI', '0.1');

--- a/lib/Collection/ReferrerCollection.php
+++ b/lib/Collection/ReferrerCollection.php
@@ -79,7 +79,7 @@ class ReferrerCollection extends AbstractLazyCollection
         //       initialized, but if we don't do this, we won't know how many items are in the
         //       collection, as one node could have many referring properties.
         foreach ($references as $reference) {
-            /** @var PropertyInterface $reference */
+            /* @var PropertyInterface $reference */
             $referrerNode = $reference->getParent();
             $this->documents[$referrerNode->getIdentifier()] = $referrerNode;
         }

--- a/lib/DocumentInspector.php
+++ b/lib/DocumentInspector.php
@@ -61,7 +61,7 @@ class DocumentInspector
         $parentNode = $this->getNode($document)->getParent();
 
         if (!$parentNode) {
-            return null;
+            return;
         }
 
         return $this->proxyFactory->createProxyForNode($document, $parentNode);

--- a/lib/Event/CreateEvent.php
+++ b/lib/Event/CreateEvent.php
@@ -33,6 +33,7 @@ class CreateEvent extends AbstractEvent
 
     /**
      * @return object
+     *
      * @throws \RuntimeException
      */
     public function getDocument()

--- a/lib/Event/FindEvent.php
+++ b/lib/Event/FindEvent.php
@@ -56,7 +56,7 @@ class FindEvent extends AbstractEvent
             'i:%s d:%s l:%s',
             $this->identifier,
             $this->document ? spl_object_hash($this->document) : '<no document>',
-            $this->locale ? : '<no locale>'
+            $this->locale ?: '<no locale>'
         );
     }
 
@@ -78,6 +78,7 @@ class FindEvent extends AbstractEvent
 
     /**
      * @return object
+     *
      * @throws DocumentManagerException
      */
     public function getDocument()

--- a/lib/Event/QueryCreateBuilderEvent.php
+++ b/lib/Event/QueryCreateBuilderEvent.php
@@ -31,6 +31,7 @@ class QueryCreateBuilderEvent extends AbstractEvent
 
     /**
      * @return mixed
+     *
      * @throws DocumentManagerException
      */
     public function getQueryBuilder()

--- a/lib/NodeManager.php
+++ b/lib/NodeManager.php
@@ -14,9 +14,9 @@ namespace Sulu\Component\DocumentManager;
 use PHPCR\NodeInterface;
 use PHPCR\RepositoryException;
 use PHPCR\SessionInterface;
+use PHPCR\Util\NodeHelper;
 use PHPCR\Util\UUIDHelper;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
-use PHPCR\Util\NodeHelper;
 
 /**
  * The node manager is responsible for talking to the PHPCR

--- a/lib/PathBuilder.php
+++ b/lib/PathBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Sulu\Component\DocumentManager;
+
+/**
+ * The path builder provides a way to create paths from templates
+ */
+class PathBuilder
+{
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $registry;
+
+    /**
+     * @param PathSegmentRegistry $registry
+     */
+    public function __construct(PathSegmentRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Build a path from an array of path segments.
+     *
+     * Segments demarcated by "%" characters will be interpreted as path
+     * segment *names* and their value will be resolved from the PathSegmentRegistry.
+     *
+     * Other segments will be interpreted literally.
+     *
+     * The following:
+     *
+     * ````
+     * $path = $pathBuilder->build(array('%base%', 'hello', '%articles%'));
+     * ````
+     *
+     * Will yield `/cms/hello/articleDirectory` where `%base%` is "cms" and
+     * `%articles` is "articleDirectory"
+     *
+     * @see Sulu\Component\DocumentManager\PathSegmentRegistry
+     *
+     * @param array $segments
+     * @return string
+     */
+    public function build($segments)
+    {
+        $results = array();
+        foreach ($segments as $segment) {
+            $result = $this->buildSegment($segment);
+
+            if (null === $result) {
+                continue;
+            }
+
+            $results[] = $result;
+        }
+
+        return '/' . implode('/', $results);
+    }
+
+    /**
+     * @param string $segment
+     */
+    private function buildSegment($segment)
+    {
+        if (empty($segment) || $segment == '/') {
+            return null;
+        }
+
+        if (substr($segment, 0, 1) == '%') {
+            if (substr($segment, -1) == '%') {
+                return $this->registry->getPathSegment(substr($segment, 1, -1));
+            }
+        }
+
+        return $segment;
+    }
+}

--- a/lib/PathBuilder.php
+++ b/lib/PathBuilder.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Component\DocumentManager;
 
 /**
- * The path builder provides a way to create paths from templates
+ * The path builder provides a way to create paths from templates.
  */
 class PathBuilder
 {
@@ -40,9 +49,10 @@ class PathBuilder
      * @see Sulu\Component\DocumentManager\PathSegmentRegistry
      *
      * @param array $segments
+     *
      * @return string
      */
-    public function build($segments)
+    public function build(array $segments)
     {
         $results = array();
         foreach ($segments as $segment) {
@@ -64,7 +74,7 @@ class PathBuilder
     private function buildSegment($segment)
     {
         if (empty($segment) || $segment == '/') {
-            return null;
+            return;
         }
 
         if (substr($segment, 0, 1) == '%') {

--- a/lib/Query/Query.php
+++ b/lib/Query/Query.php
@@ -83,6 +83,7 @@ class Query
      * @param string $hydrationMode
      *
      * @return mixed|\PHPCR\Query\QueryResultInterface
+     *
      * @throws DocumentManagerException
      */
     public function execute(array $parameters = array(), $hydrationMode = self::HYDRATE_DOCUMENT)

--- a/lib/Strategy/MixinStrategy.php
+++ b/lib/Strategy/MixinStrategy.php
@@ -54,10 +54,10 @@ class MixinStrategy implements DocumentStrategyInterface
     public function resolveMetadataForNode(NodeInterface $node)
     {
         if (false === $node->hasProperty('jcr:mixinTypes')) {
-            return null;
+            return;
         }
 
-        $mixinTypes = (array)$node->getPropertyValue('jcr:mixinTypes');
+        $mixinTypes = (array) $node->getPropertyValue('jcr:mixinTypes');
 
         foreach ($mixinTypes as $mixinType) {
             if (true == $this->metadataFactory->hasMetadataForPhpcrType($mixinType)) {
@@ -65,6 +65,6 @@ class MixinStrategy implements DocumentStrategyInterface
             }
         }
 
-        return null;
+        return;
     }
 }

--- a/lib/Subscriber/Behavior/Audit/BlameSubscriber.php
+++ b/lib/Subscriber/Behavior/Audit/BlameSubscriber.php
@@ -115,7 +115,7 @@ class BlameSubscriber implements EventSubscriberInterface
         $token = $this->tokenStorage->getToken();
 
         if (null === $token || $token instanceof AnonymousToken) {
-            return null;
+            return;
         }
 
         $user = $token->getUser();

--- a/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -24,7 +24,6 @@ use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\NameResolver;
 use Sulu\Component\DocumentManager\NodeManager;
 use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -164,7 +163,7 @@ class AutoNameSubscriber implements EventSubscriberInterface
      */
     private function rename(NodeInterface $node, $name)
     {
-        $names = (array)$node->getParent()->getNodeNames();
+        $names = (array) $node->getParent()->getNodeNames();
         $pos = array_search($node->getName(), $names);
         $next = isset($names[$pos + 1]) ? $names[$pos + 1] : null;
 

--- a/lib/Subscriber/Phpcr/RemoveSubscriber.php
+++ b/lib/Subscriber/Phpcr/RemoveSubscriber.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
 
-use PHPCR\NodeInterface;
-use PHPCR\PropertyInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Events;

--- a/lib/Subscriber/Phpcr/ReorderSubscriber.php
+++ b/lib/Subscriber/Phpcr/ReorderSubscriber.php
@@ -84,7 +84,7 @@ class ReorderSubscriber implements EventSubscriberInterface
     private function resolveSiblingName($siblingId, NodeInterface $parentNode, NodeInterface $node)
     {
         if (null === $siblingId) {
-            return null;
+            return;
         }
 
         $siblingPath = $siblingId;

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -83,5 +83,3 @@
     </services>
 
 </container>
-
-

--- a/tests/Bench/BaseBench.php
+++ b/tests/Bench/BaseBench.php
@@ -11,17 +11,14 @@
 
 namespace Sulu\Component\DocumentManager\Tests\Bench;
 
-use Sulu\Component\DocumentManager\Tests\Bootstrap;
-use Sulu\Component\DocumentManager\Subscriber\Behavior;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use PhpBench\Benchmark;
+use Sulu\Component\DocumentManager\Tests\Bootstrap;
 
 abstract class BaseBench implements Benchmark
 {
     const BASE_NAME = 'test';
     const BASE_PATH = '/test';
 
-    private $session;
     private $container;
 
     protected function initPhpcr()
@@ -50,6 +47,7 @@ abstract class BaseBench implements Benchmark
     protected function getSession()
     {
         $session = $this->getContainer()->get('doctrine_phpcr.default_session');
+
         return $session;
     }
 
@@ -58,4 +56,3 @@ abstract class BaseBench implements Benchmark
         return $this->getContainer()->get('sulu_document_manager.document_manager');
     }
 }
-

--- a/tests/Bench/BenchmarkBench.php
+++ b/tests/Bench/BenchmarkBench.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\DocumentManager\Tests\Bench;
 
-use PhpBench\BenchCase;
 use PhpBench\Benchmark\Iteration;
 
 class BenchmarkBench extends BaseBench
@@ -37,7 +36,7 @@ class BenchmarkBench extends BaseBench
             $document = $manager->create('full');
             foreach ($locales as $locale) {
                 $manager->persist($document, $locale, array(
-                    'path' => self::BASE_PATH . '/node-' . $i
+                    'path' => self::BASE_PATH . '/node-' . $i,
                 ));
             }
         }
@@ -61,8 +60,8 @@ class BenchmarkBench extends BaseBench
             $node = $baseNode->addNode('node-' . $i);
             foreach ($iteration->getParameter('locales') as $locale) {
                 $node->addMixin('mix:test');
-                $node->setProperty('lsys:' . $locale .'-created', new \DateTime());
-                $node->setProperty('lsys:' . $locale .'-changed', new \DateTime());
+                $node->setProperty('lsys:' . $locale . '-created', new \DateTime());
+                $node->setProperty('lsys:' . $locale . '-changed', new \DateTime());
             }
         }
 
@@ -76,10 +75,10 @@ class BenchmarkBench extends BaseBench
                 'nb_nodes' => 1,
             ),
             array(
-                'nb_nodes' => 10, 
+                'nb_nodes' => 10,
             ),
             array(
-                'nb_nodes' => 100, 
+                'nb_nodes' => 100,
             ),
         );
     }

--- a/tests/Bench/PathBuilderBench.php
+++ b/tests/Bench/PathBuilderBench.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Sulu\Component\DocumentManager\Tests\Bench;
+namespace Sulu\Component\DocumentManager\tests\Bench;
 
+use PhpBench\Benchmark;
 use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
-use PhpBench\Benchmark;
 
 class PathBuilderBench implements Benchmark
 {
@@ -33,12 +33,11 @@ class PathBuilderBench implements Benchmark
     {
         return array(
             array(
-                'elements' => array('one', 'two', 'three')
+                'elements' => array('one', 'two', 'three'),
             ),
             array(
                 'elements' => array('%one', '%two%', 'three'),
             ),
         );
     }
-
 }

--- a/tests/Bench/PathBuilderBench.php
+++ b/tests/Bench/PathBuilderBench.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Sulu\Component\DocumentManager\Tests\Bench;
+
+use Sulu\Component\DocumentManager\PathBuilder;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use PhpBench\Benchmark;
+
+class PathBuilderBench implements Benchmark
+{
+    private $pathBuilder;
+
+    public function setUp()
+    {
+        $registry = new PathSegmentRegistry(array(
+            'one' => 'hello',
+            'two' => 'goodbye',
+        ));
+        $this->pathBuilder = new PathBuilder($registry);
+    }
+    /**
+     * @description Build path 1000 times
+     * @revs 1000
+     * @beforeMethod setUp
+     * @paramProvider provideElements
+     */
+    public function benchBuild($iteration)
+    {
+        $this->pathBuilder->build($iteration->getParameter('elements'));
+    }
+
+    public function provideElements()
+    {
+        return array(
+            array(
+                'elements' => array('one', 'two', 'three')
+            ),
+            array(
+                'elements' => array('%one', '%two%', 'three'),
+            ),
+        );
+    }
+
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -9,19 +9,16 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests;
+namespace Sulu\Component\DocumentManager\tests;
 
 use Jackalope\RepositoryFactoryDoctrineDBAL;
-use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
-use Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher;
-use Symfony\Component\Stopwatch\Stopwatch;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use PHPCR\SessionInterface;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 
 class Bootstrap
 {
@@ -35,21 +32,19 @@ class Bootstrap
 
         $container = new ContainerBuilder();
         $container->set('doctrine_phpcr.default_session', self::createSession());
-        $stopwatch = new Stopwatch();
         $logger = new Logger('test');
-        $logger->pushHandler(new StreamHandler($logDir .'/test.log'));
+        $logger->pushHandler(new StreamHandler($logDir . '/test.log'));
 
-        //$dispatcher = new DebugEventDispatcher($container, $stopwatch, $logger);
         $dispatcher = new ContainerAwareEventDispatcher($container);
         $container->set('sulu_document_manager.event_dispatcher', $dispatcher);
 
         $config = array(
             'sulu_document_manager.default_locale' => 'en',
-            'sulu_document_manager.mapping'=> array(
+            'sulu_document_manager.mapping' => array(
                 'full' => array(
                     'alias' => 'full',
                     'phpcr_type' => 'mix:test',
-                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument'
+                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument',
                 ),
             ),
             'sulu_document_manager.namespace_mapping' => array(
@@ -77,13 +72,13 @@ class Bootstrap
     }
 
     /**
-     * Create a new PHPCR session
+     * Create a new PHPCR session.
      *
      * @return SessionInterface
      */
     public static function createSession()
     {
-        $transportName = getenv('SULU_DM_TRANSPORT') ? : 'jackalope-doctrine-dbal';
+        $transportName = getenv('SULU_DM_TRANSPORT') ?: 'jackalope-doctrine-dbal';
 
         switch ($transportName) {
             case 'jackalope-doctrine-dbal':
@@ -104,7 +99,7 @@ class Bootstrap
             'host' => 'localhost',
             'user' => 'admin',
             'password' => 'admin',
-            'path' => __DIR__ . '/../data/test.sqlite'
+            'path' => __DIR__ . '/../data/test.sqlite',
         ));
 
         return $connection;

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -9,11 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Functional;
+namespace Sulu\Component\DocumentManager\tests\Functional;
 
 use Sulu\Component\DocumentManager\Tests\Bootstrap;
-use Sulu\Component\DocumentManager\Subscriber\Behavior;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 {
@@ -59,9 +57,8 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
         foreach ($options['locales'] as $locale) {
             $manager->persist($document, $locale, array(
-                'path' => self::BASE_PATH
+                'path' => self::BASE_PATH,
             ));
         }
     }
 }
-

--- a/tests/Functional/DocumentManager/FindTest.php
+++ b/tests/Functional/DocumentManager/FindTest.php
@@ -9,12 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Functional\DocumentManager;
+namespace Sulu\Component\DocumentManager\tests\Functional\DocumentManager;
 
 use Sulu\Component\DocumentManager\Tests\Functional\BaseTestCase;
-use Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument;
 
-class DocumentManagerTest extends BaseTestCase
+class FindTest extends BaseTestCase
 {
     public function setUp()
     {
@@ -22,7 +21,7 @@ class DocumentManagerTest extends BaseTestCase
     }
 
     /**
-     * Persist a document in a single locale
+     * Persist a document in a single locale.
      */
     public function testPersist()
     {
@@ -38,7 +37,7 @@ class DocumentManagerTest extends BaseTestCase
     }
 
     /**
-     * Persist a document in a many locales
+     * Persist a document in a many locales.
      */
     public function testPersistManyLocales()
     {

--- a/tests/Functional/Model/FullDocument.php
+++ b/tests/Functional/Model/FullDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sulu CMS.
  *
@@ -48,7 +49,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getNodeName() 
+    public function getNodeName()
     {
         return $this->nodeName;
     }
@@ -56,7 +57,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getCreated() 
+    public function getCreated()
     {
         return $this->created;
     }
@@ -64,7 +65,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getChanged() 
+    public function getChanged()
     {
         return $this->changed;
     }
@@ -72,7 +73,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getCreator() 
+    public function getCreator()
     {
         return $this->creator;
     }
@@ -80,7 +81,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getChanger() 
+    public function getChanger()
     {
         return $this->changer;
     }
@@ -88,7 +89,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getParent() 
+    public function getParent()
     {
         return $this->parent;
     }
@@ -104,7 +105,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getUuid() 
+    public function getUuid()
     {
         return $this->uuid;
     }
@@ -128,7 +129,7 @@ class FullDocument implements
     /**
      * {@inheritDoc}
      */
-    public function getPath() 
+    public function getPath()
     {
         return $this->path;
     }

--- a/tests/Unit/NodeManagerTest.php
+++ b/tests/Unit/NodeManagerTest.php
@@ -129,7 +129,7 @@ class NodeManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should purge the workspace
+     * It should purge the workspace.
      */
     public function testPurgeWorkspace()
     {

--- a/tests/Unit/PathBuilderTest.php
+++ b/tests/Unit/PathBuilderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Sulu\Component\DocumentManager\Tests\Unit;
+namespace Sulu\Component\DocumentManager\tests\Unit;
 
-use Sulu\Component\DocumentManager\PathSegmentRegistry;
-use Sulu\Component\DocumentManager\PathBuilder;
 use PhpBench\Benchmark;
+use Sulu\Component\DocumentManager\PathBuilder;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
 
 class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
 {
@@ -20,18 +20,8 @@ class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
     }
 
     /**
-     * @description Build path 1000 times
-     * @revs 1000
-     * @beforeMethod setUp
-     */
-    public function benchBuild()
-    {
-        $this->pathBuilder->build(array('%one%', '%two%', 'four'));
-    }
-
-    /**
      * It should build a path
-     * Using a combination of tokens and literal values
+     * Using a combination of tokens and literal values.
      */
     public function testBuild()
     {
@@ -40,7 +30,7 @@ class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
     }
 
     /**
-     * It should build "/" for an empty array
+     * It should build "/" for an empty array.
      */
     public function testBuildEmpty()
     {
@@ -48,7 +38,7 @@ class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
     }
 
     /**
-     * It should build "/" for an array with "/"
+     * It should build "/" for an array with "/".
      */
     public function testBuildSingleSlash()
     {
@@ -56,10 +46,18 @@ class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
     }
 
     /**
-     * It should replace "//" with "/"
+     * It should replace "//" with "/".
      */
     public function testBuildNoDoubleSlash()
     {
         $this->assertEquals('/hello/world', $this->pathBuilder->build(array('hello', '', '', 'world')));
+    }
+
+    /**
+     * It should allow sub paths.
+     */
+    public function testBuildSubPath()
+    {
+        $this->assertEquals('/hello/world/goodbye/world/k', $this->pathBuilder->build(array('hello', 'world/goodbye/world', 'k')));
     }
 }

--- a/tests/Unit/PathBuilderTest.php
+++ b/tests/Unit/PathBuilderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use Sulu\Component\DocumentManager\PathBuilder;
+use PhpBench\Benchmark;
+
+class PathBuilderTest extends \PHPUnit_Framework_TestCase implements Benchmark
+{
+    private $pathBuilder;
+
+    public function setUp()
+    {
+        $pathRegistry = new PathSegmentRegistry(array(
+            'one' => 'one',
+            'two' => 'two',
+        ));
+        $this->pathBuilder = new PathBuilder($pathRegistry);
+    }
+
+    /**
+     * @description Build path 1000 times
+     * @revs 1000
+     * @beforeMethod setUp
+     */
+    public function benchBuild()
+    {
+        $this->pathBuilder->build(array('%one%', '%two%', 'four'));
+    }
+
+    /**
+     * It should build a path
+     * Using a combination of tokens and literal values
+     */
+    public function testBuild()
+    {
+        $result = $this->pathBuilder->build(array('%one%', '%two%', 'four'));
+        $this->assertEquals('/one/two/four', $result);
+    }
+
+    /**
+     * It should build "/" for an empty array
+     */
+    public function testBuildEmpty()
+    {
+        $this->assertEquals('/', $this->pathBuilder->build(array()));
+    }
+
+    /**
+     * It should build "/" for an array with "/"
+     */
+    public function testBuildSingleSlash()
+    {
+        $this->assertEquals('/', $this->pathBuilder->build(array('/')));
+    }
+
+    /**
+     * It should replace "//" with "/"
+     */
+    public function testBuildNoDoubleSlash()
+    {
+        $this->assertEquals('/hello/world', $this->pathBuilder->build(array('hello', '', '', 'world')));
+    }
+}


### PR DESCRIPTION
This PR introduces the path builder.

The path builder allows you to construct paths by providing an array of path segments. If a path segment is demarcated with `%` then it will be resolved by the `PathSegmentRegistry`.

``` php
$builder->build('%base%', 'sulu_io', '%content%', 'path/to/article');

echo $path; // /cmf/sulu_io/contents/path/to/article
```

This replaces the functionality of the Sulu `SessionManager`.

Note that I had originally planned to make something cleverer, e.g. `$builder->segment('webspace', $webspace->getKey())->add('foobar')`. This enforces a kind of "schema" but is inherently more complicated.

I think the approach I have done here is flexible and simple, and does not require any additional classes or configuration - at the cost of being less schematic.
