### PR TITLE
added options to all required events

### DIFF
--- a/lib/Collection/QueryResultCollection.php
+++ b/lib/Collection/QueryResultCollection.php
@@ -37,6 +37,11 @@ class QueryResultCollection extends AbstractLazyCollection
     private $locale;
 
     /**
+     * @var array
+     */
+    private $options;
+
+    /**
      * @var bool
      */
     private $initialized = false;
@@ -50,17 +55,20 @@ class QueryResultCollection extends AbstractLazyCollection
      * @param QueryResultInterface $result
      * @param EventDispatcherInterface $eventDispatcher
      * @param string $locale
+     * @param array $options
      * @param null|string $primarySelector
      */
     public function __construct(
         QueryResultInterface $result,
         EventDispatcherInterface $eventDispatcher,
         $locale,
+        $options = array(),
         $primarySelector = null
     ) {
         $this->result = $result;
         $this->eventDispatcher = $eventDispatcher;
         $this->locale = $locale;
+        $this->options = $options;
         $this->primarySelector = $primarySelector;
     }
 
@@ -73,7 +81,7 @@ class QueryResultCollection extends AbstractLazyCollection
         $row = $this->documents->current();
         $node = $row->getNode($this->primarySelector);
 
-        $hydrateEvent = new HydrateEvent($node, $this->locale);
+        $hydrateEvent = new HydrateEvent($node, $this->locale, $this->options);
         $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
 
         return $hydrateEvent->getDocument();

--- a/lib/DocumentInspector.php
+++ b/lib/DocumentInspector.php
@@ -105,10 +105,11 @@ class DocumentInspector
     }
 
     /**
-     * Return true if the document has children
+     * Return true if the document has children.
      *
      * @param object $document
-     * @return boolean
+     *
+     * @return bool
      */
     public function hasChildren($document)
     {

--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -137,9 +137,9 @@ class DocumentManager implements DocumentManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function createQuery($query, $locale = null)
+    public function createQuery($query, $locale = null, array $options = array())
     {
-        $event = new Event\QueryCreateEvent($query, $locale);
+        $event = new Event\QueryCreateEvent($query, $locale, $options);
         $this->eventDispatcher->dispatch(Events::QUERY_CREATE, $event);
 
         return $event->getQuery();

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Sulu
  *
@@ -7,6 +8,7 @@
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
 namespace Sulu\Component\DocumentManager;
 
 use Sulu\Component\DocumentManager\Query\Query;

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -111,10 +111,11 @@ interface DocumentManagerInterface
      *
      * @param mixed $query Either a JCR-SQL2 string, or a PHPCR query object
      * @param string $locale
+     * @param array $options
      *
      * @return Query
      */
-    public function createQuery($query, $locale = null);
+    public function createQuery($query, $locale = null, array $options = array());
 
     /**
      * Create a new query builder.

--- a/lib/Event/AbstractMappingEvent.php
+++ b/lib/Event/AbstractMappingEvent.php
@@ -16,6 +16,8 @@ use Sulu\Component\DocumentManager\DocumentAccessor;
 
 abstract class AbstractMappingEvent extends AbstractEvent
 {
+    use EventOptionsTrait;
+
     /**
      * @var object
      */
@@ -35,11 +37,6 @@ abstract class AbstractMappingEvent extends AbstractEvent
      * @var DocumentAccessor
      */
     protected $accessor;
-
-    /**
-     * @var array
-     */
-    protected $options;
 
     /**
      * {@inheritDoc}
@@ -108,28 +105,5 @@ abstract class AbstractMappingEvent extends AbstractEvent
     public function hasNode()
     {
         return null !== $this->node;
-    }
-
-    /**
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * @param string $name
-     * @param null|mixed $default
-     *
-     * @return mixed
-     */
-    public function getOption($name, $default = null)
-    {
-        if (isset($this->options[$name])) {
-            return $this->options[$name];
-        }
-
-        return $default;
     }
 }

--- a/lib/Event/ConfigureOptionsEvent.php
+++ b/lib/Event/ConfigureOptionsEvent.php
@@ -15,10 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConfigureOptionsEvent extends AbstractEvent
 {
-    /**
-     * @var OptionsResolver
-     */
-    private $options;
+    use EventOptionsTrait;
 
     /**
      * @param OptionsResolver $options
@@ -26,13 +23,5 @@ class ConfigureOptionsEvent extends AbstractEvent
     public function __construct(OptionsResolver $options)
     {
         $this->options = $options;
-    }
-
-    /**
-     * @return OptionsResolver
-     */
-    public function getOptions()
-    {
-        return $this->options;
     }
 }

--- a/lib/Event/EventOptionsTrait.php
+++ b/lib/Event/EventOptionsTrait.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * This file is part of Sulu
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Sulu\Component\DocumentManager\Event;
+
+/**
+ * This trait adds options to an event
+ */
+trait EventOptionsTrait
+{
+    /**
+     * This array is used as key value storage for the options
+     * @var array
+     */
+    protected $options = array();
+
+    /**
+     * Returns all the options for the event
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Returns the option with the given name
+     * @param string $name The name of the option
+     * @param mixed $default The return value in case the option is not set
+     *
+     * @return mixed The value of the option
+     */
+    public function getOption($name, $default = null) {
+        if (isset($this->options[$name])) {
+            return $this->options[$name];
+        }
+
+        return $default;
+    }
+}

--- a/lib/Event/EventOptionsTrait.php
+++ b/lib/Event/EventOptionsTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Sulu
  *
@@ -7,21 +8,23 @@
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
 namespace Sulu\Component\DocumentManager\Event;
 
 /**
- * This trait adds options to an event
+ * This trait adds options to an event.
  */
 trait EventOptionsTrait
 {
     /**
-     * This array is used as key value storage for the options
+     * This array is used as key value storage for the options.
+     *
      * @var array
      */
     protected $options = array();
 
     /**
-     * Returns all the options for the event
+     * Returns all the options for the event.
      *
      * @return array
      */
@@ -31,13 +34,15 @@ trait EventOptionsTrait
     }
 
     /**
-     * Returns the option with the given name
+     * Returns the option with the given name.
+     *
      * @param string $name The name of the option
      * @param mixed $default The return value in case the option is not set
      *
      * @return mixed The value of the option
      */
-    public function getOption($name, $default = null) {
+    public function getOption($name, $default = null)
+    {
         if (isset($this->options[$name])) {
             return $this->options[$name];
         }

--- a/lib/Event/FindEvent.php
+++ b/lib/Event/FindEvent.php
@@ -15,6 +15,8 @@ use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 
 class FindEvent extends AbstractEvent
 {
+    use EventOptionsTrait;
+
     /**
      * @var string
      */
@@ -24,11 +26,6 @@ class FindEvent extends AbstractEvent
      * @var string
      */
     private $locale;
-
-    /**
-     * @var array
-     */
-    private $options = array();
 
     /**
      * @var object
@@ -99,13 +96,5 @@ class FindEvent extends AbstractEvent
     public function setDocument($document)
     {
         $this->document = $document;
-    }
-
-    /**
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
     }
 }

--- a/lib/Event/QueryCreateEvent.php
+++ b/lib/Event/QueryCreateEvent.php
@@ -16,6 +16,8 @@ use Sulu\Component\DocumentManager\Query\Query;
 
 class QueryCreateEvent extends AbstractEvent
 {
+    use EventOptionsTrait;
+
     /**
      * @var string
      */
@@ -39,12 +41,14 @@ class QueryCreateEvent extends AbstractEvent
     /**
      * @param string $innerQuery
      * @param string $locale
+     * @param array $options
      * @param null|string $primarySelector
      */
-    public function __construct($innerQuery, $locale, $primarySelector = null)
+    public function __construct($innerQuery, $locale, array $options, $primarySelector = null)
     {
         $this->innerQuery = $innerQuery;
         $this->locale = $locale;
+        $this->options = $options;
         $this->primarySelector = $primarySelector;
     }
 

--- a/lib/Event/QueryCreateEvent.php
+++ b/lib/Event/QueryCreateEvent.php
@@ -44,7 +44,7 @@ class QueryCreateEvent extends AbstractEvent
      * @param array $options
      * @param null|string $primarySelector
      */
-    public function __construct($innerQuery, $locale, array $options, $primarySelector = null)
+    public function __construct($innerQuery, $locale, array $options = array(), $primarySelector = null)
     {
         $this->innerQuery = $innerQuery;
         $this->locale = $locale;

--- a/lib/Event/QueryExecuteEvent.php
+++ b/lib/Event/QueryExecuteEvent.php
@@ -16,6 +16,8 @@ use Sulu\Component\DocumentManager\Query\Query;
 
 class QueryExecuteEvent extends AbstractEvent
 {
+    use EventOptionsTrait;
+
     /**
      * @var Query
      */
@@ -28,10 +30,12 @@ class QueryExecuteEvent extends AbstractEvent
 
     /**
      * @param Query $query
+     * @param array $options
      */
-    public function __construct(Query $query)
+    public function __construct(Query $query, array $options = array())
     {
         $this->query = $query;
+        $this->options = $options;
     }
 
     /**

--- a/lib/Events.php
+++ b/lib/Events.php
@@ -78,7 +78,7 @@ class Events
     /**
      * Fired when a query should be created from a query string.
      */
-    const QUERY_CREATE  = 'sulu_document_manager.query.create';
+    const QUERY_CREATE = 'sulu_document_manager.query.create';
 
     /**
      * Fired when a new query builder should be created.

--- a/lib/NameResolver.php
+++ b/lib/NameResolver.php
@@ -40,7 +40,7 @@ class NameResolver
 
             $hasChild = $parentNode->hasNode($name);
 
-            $index++;
+            ++$index;
         } while ($hasChild);
 
         return $name;

--- a/lib/Query/Query.php
+++ b/lib/Query/Query.php
@@ -51,6 +51,11 @@ class Query
     private $locale;
 
     /**
+     * @var array
+     */
+    private $options;
+
+    /**
      * @var int
      */
     private $maxResults;
@@ -64,17 +69,20 @@ class Query
      * @param QueryInterface $phpcrQuery
      * @param EventDispatcherInterface $dispatcher
      * @param null|string $locale
+     * @param array $options
      * @param null|string $primarySelector
      */
     public function __construct(
         QueryInterface $phpcrQuery,
         EventDispatcherInterface $dispatcher,
         $locale = null,
+        array $options = array(),
         $primarySelector = null
     ) {
         $this->phpcrQuery = $phpcrQuery;
         $this->dispatcher = $dispatcher;
         $this->locale = $locale;
+        $this->options = $options;
         $this->primarySelector = $primarySelector;
     }
 
@@ -111,7 +119,7 @@ class Query
             ));
         }
 
-        $event = new QueryExecuteEvent($this);
+        $event = new QueryExecuteEvent($this, $this->options);
         $this->dispatcher->dispatch(Events::QUERY_EXECUTE, $event);
 
         return $event->getResult();

--- a/lib/Subscriber/Behavior/Path/AliasFilingSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AliasFilingSubscriber.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
 
 use Sulu\Component\DocumentManager\Behavior\Path\AliasFilingBehavior;
-use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\NodeManager;

--- a/lib/Subscriber/Phpcr/QuerySubscriber.php
+++ b/lib/Subscriber/Phpcr/QuerySubscriber.php
@@ -85,6 +85,7 @@ class QuerySubscriber implements EventSubscriberInterface
                 $phpcrQuery,
                 $this->eventDispatcher,
                 $event->getLocale(),
+                $event->getOptions(),
                 $event->getPrimarySelector()
             )
         );
@@ -114,7 +115,9 @@ class QuerySubscriber implements EventSubscriberInterface
         $locale = $query->getLocale();
         $phpcrResult = $query->getPhpcrQuery()->execute();
 
-        $event->setResult(new QueryResultCollection($phpcrResult, $this->eventDispatcher, $locale));
+        $event->setResult(
+            new QueryResultCollection($phpcrResult, $this->eventDispatcher, $locale, $event->getOptions())
+        );
     }
 
     /**

--- a/tests/Bench/BenchmarkBench.php
+++ b/tests/Bench/BenchmarkBench.php
@@ -32,7 +32,7 @@ class BenchmarkBench extends BaseBench
         $manager = $this->getDocumentManager();
         $locales = $iteration->getParameter('locales');
 
-        for ($i = 0; $i < $iteration->getParameter('nb_nodes'); $i++) {
+        for ($i = 0; $i < $iteration->getParameter('nb_nodes'); ++$i) {
             $document = $manager->create('full');
             foreach ($locales as $locale) {
                 $manager->persist($document, $locale, array(
@@ -56,7 +56,7 @@ class BenchmarkBench extends BaseBench
         $session = $this->getSession();
         $baseNode = $session->getNode(self::BASE_PATH);
 
-        for ($i = 0; $i < $iteration->getParameter('nb_nodes'); $i++) {
+        for ($i = 0; $i < $iteration->getParameter('nb_nodes'); ++$i) {
             $node = $baseNode->addNode('node-' . $i);
             foreach ($iteration->getParameter('locales') as $locale) {
                 $node->addMixin('mix:test');

--- a/tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/tests/Unit/Collection/QueryResultCollectionTest.php
@@ -21,6 +21,7 @@ class QueryResultCollectionTest extends \PHPUnit_Framework_TestCase
             $this->queryResult->reveal(),
             $this->dispatcher->reveal(),
             'fr',
+            array(),
             's'
         );
 

--- a/tests/Unit/DocumentInspectorTest.php
+++ b/tests/Unit/DocumentInspectorTest.php
@@ -103,7 +103,7 @@ class DocumentInspectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should return true if it has children
+     * It should return true if it has children.
      */
     public function testHasChildren()
     {

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -25,7 +25,7 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should return the reflection class
+     * It should return the reflection class.
      */
     public function testReflectionClass()
     {

--- a/tests/Unit/Query/QueryTest.php
+++ b/tests/Unit/Query/QueryTest.php
@@ -22,6 +22,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             'fr',
+            array(),
             'p'
         );
     }

--- a/tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -25,7 +25,7 @@ class InstantiatorSubscriberTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->metadata = $this->prophesize(Metadata::class);
-        $this->hydrateEvent =  $this->prophesize(HydrateEvent::class);
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
         $this->createEvent = $this->prophesize(CreateEvent::class);
         $this->node = $this->prophesize(NodeInterface::class);
     }

--- a/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -25,6 +25,56 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var WorkspaceInterface
+     */
+    private $workspace;
+
+    /**
+     * @var QueryManagerInterface
+     */
+    private $queryManager;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var QueryInterface
+     */
+    private $phpcrQuery;
+
+    /**
+     * @var QueryResultInterface
+     */
+    private $phpcrResult;
+
+    /**
+     * @var QueryCreateEvent
+     */
+    private $queryCreateEvent;
+
+    /**
+     * @var QueryExecuteEvent
+     */
+    private $queryExecuteEvent;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var QuerySubscriber
+     */
+    private $subscriber;
+
     public function setUp()
     {
         $this->session = $this->prophesize(SessionInterface::class);
@@ -57,12 +107,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($query);
         $this->queryCreateEvent->getLocale()->willReturn($locale);
+        $this->queryCreateEvent->getOptions()->willReturn(array());
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($query, 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
+            array(),
             $primarySelector
         ))->shouldBeCalled();
 
@@ -79,12 +131,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->getLocale()->willReturn($locale);
+        $this->queryCreateEvent->getOptions()->willReturn(array());
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($this->phpcrQuery->reveal(), 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
+            array(),
             $primarySelector
         ))->shouldBeCalled();
 
@@ -104,6 +158,7 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
         $this->phpcrQuery->execute()->willReturn($this->phpcrResult->reveal());
         $this->query->getPrimarySelector()->willReturn($primarySelector);
         $this->queryExecuteEvent->getQuery()->willReturn($this->query->reveal());
+        $this->queryExecuteEvent->getOptions()->willReturn(array());
 
         $this->queryExecuteEvent->setResult(
             new QueryResultCollection(

--- a/tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
@@ -87,8 +87,8 @@ class ReorderSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testOrderBeforeSiblingNotLast()
     {
         $siblings = array(
-            'one' =>  $this->prophesize(NodeInterface::class),
-            'two' =>  $this->prophesize(NodeInterface::class),
+            'one' => $this->prophesize(NodeInterface::class),
+            'two' => $this->prophesize(NodeInterface::class),
         );
 
         $this->event->getDestId()->willReturn(self::UUID);
@@ -111,8 +111,8 @@ class ReorderSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testOrderAfterLast()
     {
         $siblings = array(
-            'one' =>  $this->prophesize(NodeInterface::class),
-            'two' =>  $this->prophesize(NodeInterface::class),
+            'one' => $this->prophesize(NodeInterface::class),
+            'two' => $this->prophesize(NodeInterface::class),
         );
 
         $this->event->getDestId()->willReturn(self::UUID);


### PR DESCRIPTION
I have introduced an `EventOptionsTrait`, which I have used instead of the own implementation spread over multiple events, and introduced in more events I needed.

**tasks:**
- [ ] test coverage
- [ ] gather feedback for my changes

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | none |
| BC breaks | none |
| Documentation PR | none |
