### PR TITLE
removed the locale as mandatory parameter from persist

### DIFF
--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -61,7 +61,7 @@ class DocumentManager implements DocumentManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function persist($document, $locale, array $options = [])
+    public function persist($document, $locale = null, array $options = [])
     {
         $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
 

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -47,7 +47,7 @@ interface DocumentManagerInterface
      * @param string $locale
      * @param array $options
      */
-    public function persist($document, $locale, array $options = []);
+    public function persist($document, $locale = null, array $options = []);
 
     /**
      * Remove the document. The document should be unregistered

--- a/lib/Event/EventOptionsTrait.php
+++ b/lib/Event/EventOptionsTrait.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\DocumentManager\Event;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 /**
  * This trait adds options to an event.
  */
@@ -19,14 +21,14 @@ trait EventOptionsTrait
     /**
      * This array is used as key value storage for the options.
      *
-     * @var array
+     * @var OptionsResolver
      */
-    protected $options = [];
+    protected $options;
 
     /**
      * Returns all the options for the event.
      *
-     * @return array
+     * @return OptionsResolver
      */
     public function getOptions()
     {

--- a/lib/Subscriber/Behavior/Audit/BlameSubscriber.php
+++ b/lib/Subscriber/Behavior/Audit/BlameSubscriber.php
@@ -92,8 +92,13 @@ class BlameSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $node = $event->getNode();
         $locale = $event->getLocale();
+
+        if (!$locale) {
+            return;
+        }
+
+        $node = $event->getNode();
 
         if (!$this->getCreator($node, $locale)) {
             $name = $this->encoder->localizedSystemName(self::CREATOR, $locale);
@@ -106,7 +111,7 @@ class BlameSubscriber implements EventSubscriberInterface
         $this->handleHydrate($event);
     }
 
-    private function getUserId(array $options)
+    private function getUserId($options)
     {
         if ($options['user']) {
             return $options['user'];

--- a/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -59,14 +59,20 @@ class TimestampSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $locale = $event->getLocale();
+
+        if (!$locale) {
+            return;
+        }
+
         $node = $event->getNode();
 
         if (!$document->getCreated()) {
-            $name = $this->encoder->localizedSystemName(self::CREATED, $event->getLocale());
+            $name = $this->encoder->localizedSystemName(self::CREATED, $locale);
             $node->setProperty($name, new \DateTime());
         }
 
-        $name = $this->encoder->localizedSystemName(self::CHANGED, $event->getLocale());
+        $name = $this->encoder->localizedSystemName(self::CHANGED, $locale);
         $node->setProperty($name, new \DateTime());
     }
 

--- a/tests/Unit/Subscriber/Behavior/Audit/BlameSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Audit/BlameSubscriberTest.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit;
 
+use Massive\Bundle\SearchBundle\Search\Document;
 use PHPCR\NodeInterface;
+use stdClass;
 use Sulu\Component\DocumentManager\Behavior\Audit\BlameBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
@@ -25,6 +27,71 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class BlameSubscriberTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    /**
+     * @var AnonymousToken
+     */
+    private $anonymousToken;
+
+    /**
+     * @var stdClass
+     */
+    private $notUser;
+
+    /**
+     * @var TokenInterface
+     */
+    private $token;
+
+    /**
+     * @var TokenStorage
+     */
+    private $tokenStorage;
+
+    /**
+     * @var BlameTestDocument
+     */
+    private $document;
+
+    /**
+     * @var BlameSubscriber
+     */
+    private $subscriber;
+
     public function setUp()
     {
         if (!class_exists(UserInterface::class)) {
@@ -68,6 +135,17 @@ class BlameSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->persistEvent->getDocument()->willReturn($this->document);
         $this->tokenStorage->getToken()->willReturn(null);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should return early if the locale is null.
+     */
+    public function testPersistLocaleIsNull()
+    {
+        $this->persistEvent->getLocale()->willReturn(null);
+        $this->node->setProperty()->shouldNotBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }

--- a/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
@@ -22,6 +22,51 @@ use Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\TimestampSubscriber
 
 class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var \stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var TimestampSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var \DateTime
+     */
+    private $createdDate;
+
+    /**
+     * @var \DateTime
+     */
+    private $changedDate;
+
     public function setUp()
     {
         $this->persistEvent = $this->prophesize(PersistEvent::class);
@@ -44,6 +89,20 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testPersistNotImplementing()
     {
         $this->persistEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should return early if the locale is null.
+     */
+    public function testPersistLocaleIsNull()
+    {
+        $document = new TestDocument();
+        $this->persistEvent->getDocument()->willReturn($document);
+        $this->persistEvent->getLocale()->willReturn(null);
+
+        $this->node->setProperty()->shouldNotBeCalled();
+
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 


### PR DESCRIPTION
This PR removes the locale as mandatory parameter, because sometimes you only want to persist changes that are not locale specific.

**tasks:**
- [ ] test coverage
- [ ] gather feedback for my changes

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | fixes #16 |
| BC breaks | none |
| Documentation PR | none |
