### PR TITLE
Query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sulu Document Manager
 =====================
 
-[![](https://travis-ci.org/sulu-io/sulu-document-manager.png?branch=master)](https://travis-ci.org/sulu-io/sulu-document-manager) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/sulu-io/sulu-document-manager/badges/quality-score.png?s=a4e66cebefa4fb6f55f50066d516dc4ab9ba3d86)](https://scrutinizer-ci.com/g/sulu-io/sulu-document-manager/)
+[![](https://travis-ci.org/sulu-io/sulu-document-manager.png?branch=develop)](https://travis-ci.org/sulu-io/sulu-document-manager) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/sulu-io/sulu-document-manager/badges/quality-score.png?s=develop)](https://scrutinizer-ci.com/g/sulu-io/sulu-document-manager/)
 
 100% event driven PHPCR based document manager.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "sulu/document-manager",
     "description": "Sulu Document Manager",
     "require": {
-        "doctrine/phpcr-odm": "~1.2",
+        "doctrine/phpcr-odm": "~1.3@dev",
         "symfony/event-dispatcher": "~2.0",
         "symfony-cmf/core-bundle": "~1.2",
         "ocramius/proxy-manager": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "sulu/document-manager",
     "description": "Sulu Document Manager",
     "require": {
-        "doctrine/phpcr-odm": "~1.3@dev",
+        "doctrine/phpcr-odm": "~1.3",
         "symfony/event-dispatcher": "~2.0",
         "symfony-cmf/core-bundle": "~1.2",
         "ocramius/proxy-manager": "~1.0",

--- a/lib/DocumentStrategyInterface.php
+++ b/lib/DocumentStrategyInterface.php
@@ -12,9 +12,11 @@
 namespace Sulu\Component\DocumentManager;
 
 use PHPCR\NodeInterface;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 
 /**
- * Document strategies determine how documents are managed.
+ * Document strategies determine how documents are managed, for example
+ * if the document class should be determined by a mixin, or by the primary node type.
  */
 interface DocumentStrategyInterface
 {
@@ -48,4 +50,47 @@ interface DocumentStrategyInterface
      * @return Metadata|null
      */
     public function resolveMetadataForNode(NodeInterface $node);
+
+    /**
+     * Return the primary node type from the given document class FQN.
+     *
+     * For example:
+     *
+     * ````
+     * return 'nt:unstructured';
+     * ````
+     *
+     * @param string $classFqn
+     * @return string
+     */
+    public function getPrimaryNodeType($classFqn);
+
+    /**
+     * Create a source constraint for a source document. That is return the
+     * constraint that should be used to return only documents of the given
+     * class FQN.
+     *
+     * For example:
+     *
+     * ````
+     * return $qomf->comparison(
+     *     $qomf->propertyValue(
+     *         $sourceNode->getAlias(),
+     *         'jcr:mixinTypes'
+     *     ),
+     *     QOMConstants::JCR_OPERATOR_EQUAL_TO,
+     *     $qomf->literal('foo')
+     * );
+     * ````
+     *
+     * Can return NULL if no constraints should be added. This may be required
+     * if the primary type already represents the document class.
+     *
+     * @param QueryObjectModelFactoryInterface $qomf
+     * @param string $sourceAlias
+     * @param string $classFqn
+     *
+     * @return PHPCR\Query\QOM\ConstraintInterface
+     */
+    public function createSourceConstraint(QueryObjectModelFactoryInterface $qomf, $sourceAlias, $classFqn);
 }

--- a/lib/DocumentStrategyInterface.php
+++ b/lib/DocumentStrategyInterface.php
@@ -61,6 +61,7 @@ interface DocumentStrategyInterface
      * ````
      *
      * @param string $classFqn
+     *
      * @return string
      */
     public function getPrimaryNodeType($classFqn);

--- a/lib/DocumentStrategyInterface.php
+++ b/lib/DocumentStrategyInterface.php
@@ -56,9 +56,9 @@ interface DocumentStrategyInterface
      *
      * For example:
      *
-     * ````
+     * ```
      * return 'nt:unstructured';
-     * ````
+     * ```
      *
      * @param string $classFqn
      *
@@ -73,7 +73,7 @@ interface DocumentStrategyInterface
      *
      * For example:
      *
-     * ````
+     * ```
      * return $qomf->comparison(
      *     $qomf->propertyValue(
      *         $sourceNode->getAlias(),
@@ -82,7 +82,7 @@ interface DocumentStrategyInterface
      *     QOMConstants::JCR_OPERATOR_EQUAL_TO,
      *     $qomf->literal('foo')
      * );
-     * ````
+     * ```
      *
      * Can return NULL if no constraints should be added. This may be required
      * if the primary type already represents the document class.

--- a/lib/Event/QueryCreateBuilderEvent.php
+++ b/lib/Event/QueryCreateBuilderEvent.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Component\DocumentManager\Event;
 
-use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 
 class QueryCreateBuilderEvent extends AbstractEvent
 {

--- a/lib/Event/QueryCreateBuilderEvent.php
+++ b/lib/Event/QueryCreateBuilderEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\DocumentManager\Event;
 
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
-use Sulu\Component\DocumentManager\Query\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 
 class QueryCreateBuilderEvent extends AbstractEvent
 {

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -36,7 +36,7 @@ class Metadata
     /**
      * @var array
      */
-    private $fieldMappings = array();
+    private $fieldMappings = [];
 
     /**
      * Add a field mapping for field with given name, for example:.

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -41,12 +41,12 @@ class Metadata
     /**
      * Add a field mapping for field with given name, for example:.
      *
-     * ````
+     * ```
      * $metadata->addFieldMapping(array(
      *     'encoding' => 'content',
      *     'property' => 'phpcr_property_name',
      * ));
-     * ````
+     * ```
      *
      * @param string $name Name of field/property in the mapped class.
      * @param array $mapping {

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -36,7 +36,7 @@ class Metadata
     /**
      * @var array
      */
-    private $fieldMappings;
+    private $fieldMappings = array();
 
     /**
      * Add a field mapping for field with given name, for example:.

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -82,6 +82,25 @@ class Metadata
     }
 
     /**
+     * Return the mapping for the named field.
+     *
+     * @see Metadata::addFieldMapping
+     *
+     * @return array
+     */
+    public function getFieldMapping($name)
+    {
+        if (!isset($this->fieldMappings[$name])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Field mapping "%s" not known in metadata for document type "%s". Known mappings: "%s"',
+                $name, $this->alias, implode('", "', array_keys($this->fieldMappings))
+            ));
+        }
+
+        return $this->fieldMappings[$name];
+    }
+
+    /**
      * @return string
      */
     public function getClass()

--- a/lib/Query/QueryBuilderConverter.php
+++ b/lib/Query/QueryBuilderConverter.php
@@ -107,7 +107,7 @@ class QueryBuilderConverter extends ConverterPhpcr
 
         if (count($this->sourceDocumentNodes) > 1 && null === $builder->getPrimaryAlias()) {
             throw new \InvalidArgumentException(
-                'You must specify a primary alias when selecting from multiple document sources' .
+                'You must specify a primary alias when selecting from multiple document sources ' .
                 'e.g. $qb->from(\'a\') ...'
             );
         }

--- a/lib/Query/QueryBuilderConverter.php
+++ b/lib/Query/QueryBuilderConverter.php
@@ -11,17 +11,16 @@
 
 namespace Sulu\Component\DocumentManager\Query;
 
-use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
 use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
 use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
 use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
 use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 
 /**
  * Class which converts a Builder tree to a PHPCR Query.
@@ -29,7 +28,8 @@ use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 class QueryBuilderConverter extends ConverterPhpcr
 {
     /**
-     * j
+     * j.
+     *
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
@@ -37,7 +37,7 @@ class QueryBuilderConverter extends ConverterPhpcr
     /**
      * @var Metadata[]
      */
-    protected $documentMetadata = array();
+    protected $documentMetadata = [];
 
     /**
      * @param PropertyEncoder
@@ -70,12 +70,12 @@ class QueryBuilderConverter extends ConverterPhpcr
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getQuery(QueryBuilder $builder)
     {
-        $this->documentMetadata = array();
-        $this->sourceDocumentNodes = array();
+        $this->documentMetadata = [];
+        $this->sourceDocumentNodes = [];
         $this->constraint = null;
 
         $this->locale = $builder->getLocale();
@@ -96,12 +96,12 @@ class QueryBuilderConverter extends ConverterPhpcr
             );
         }
 
-        $dispatches = array(
+        $dispatches = [
             QBConstants::NT_FROM,
             QBConstants::NT_SELECT,
             QBConstants::NT_WHERE,
             QBConstants::NT_ORDER_BY,
-        );
+        ];
 
         foreach ($dispatches as $dispatchType) {
             $this->dispatchMany($builder->getChildrenOfType($dispatchType));
@@ -123,7 +123,7 @@ class QueryBuilderConverter extends ConverterPhpcr
             $this->columns
         );
 
-        $query = new Query($phpcrQuery, $this->eventDispatcher, $this->locale, array(), $builder->getPrimaryAlias());
+        $query = new Query($phpcrQuery, $this->eventDispatcher, $this->locale, [], $builder->getPrimaryAlias());
 
         if ($firstResult = $builder->getFirstResult()) {
             $query->setFirstResult($firstResult);
@@ -137,14 +137,14 @@ class QueryBuilderConverter extends ConverterPhpcr
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function applySourceConstraints(QueryBuilder $builder)
     {
         foreach ($this->sourceDocumentNodes as $sourceDocumentNode) {
             $metadata = $this->getMetadata($sourceDocumentNode->getDocumentFqn());
             $constraint = $this->strategy->createSourceConstraint(
-                $this->qomf, 
+                $this->qomf,
                 $sourceDocumentNode->getAlias(),
                 $metadata->getClass()
             );
@@ -166,7 +166,7 @@ class QueryBuilderConverter extends ConverterPhpcr
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function walkSourceDocument(SourceDocument $node)
     {
@@ -186,7 +186,7 @@ class QueryBuilderConverter extends ConverterPhpcr
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function walkOperandDynamicField(OperandDynamicField $node)
     {
@@ -214,6 +214,7 @@ class QueryBuilderConverter extends ConverterPhpcr
      * @param string $field Name of the document field
      *
      * @return array {
+     *
      *     @var string Element is the real alias to use, second element is
      *     @var string the property name
      * }
@@ -236,13 +237,14 @@ class QueryBuilderConverter extends ConverterPhpcr
             $this->locale
         );
 
-        return array($alias, $phpcrName);
+        return [$alias, $phpcrName];
     }
 
     /**
-     * Return either the metadata for the fqn of the document, or the alias
+     * Return either the metadata for the fqn of the document, or the alias.
      *
      * @param string $documentFqn Document FQN or alias
+     *
      * @return Metadata
      */
     protected function getMetadata($documentFqn)
@@ -253,5 +255,4 @@ class QueryBuilderConverter extends ConverterPhpcr
 
         return $this->metadataFactory->getMetadataForClass($documentFqn);
     }
-
 }

--- a/lib/Query/QueryBuilderConverter.php
+++ b/lib/Query/QueryBuilderConverter.php
@@ -28,8 +28,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class QueryBuilderConverter extends ConverterPhpcr
 {
     /**
-     * j.
-     *
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;

--- a/lib/Query/QueryBuilderConverter.php
+++ b/lib/Query/QueryBuilderConverter.php
@@ -1,0 +1,257 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Query;
+
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode as QBConstants;
+use Doctrine\ODM\PHPCR\Query\Builder\ConverterPhpcr;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Sulu\Component\DocumentManager\DocumentStrategyInterface;
+
+/**
+ * Class which converts a Builder tree to a PHPCR Query.
+ */
+class QueryBuilderConverter extends ConverterPhpcr
+{
+    /**
+     * j
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var Metadata[]
+     */
+    protected $documentMetadata = array();
+
+    /**
+     * @param PropertyEncoder
+     */
+    protected $encoder;
+
+    /**
+     * @param DocumentStrategyInterface
+     */
+    private $strategy;
+
+    /**
+     * @param SessionInterface $session
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param MetadataFactoryInterface $metadataFactory
+     * @param PropertyEncoder $encoder
+     */
+    public function __construct(
+        SessionInterface $session,
+        EventDispatcherInterface $eventDispatcher,
+        MetadataFactoryInterface $metadataFactory,
+        PropertyEncoder $encoder,
+        DocumentStrategyInterface $strategy
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->qomf = $session->getWorkspace()->getQueryManager()->getQOMFactory();
+        $this->metadataFactory = $metadataFactory;
+        $this->encoder = $encoder;
+        $this->strategy = $strategy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getQuery(QueryBuilder $builder)
+    {
+        $this->documentMetadata = array();
+        $this->sourceDocumentNodes = array();
+        $this->constraint = null;
+
+        $this->locale = $builder->getLocale();
+
+        if (!$this->locale) {
+            throw new \InvalidArgumentException(sprintf(
+                'No locale specified'
+            ));
+        }
+
+        $from = $builder->getChildrenOfType(
+            QBConstants::NT_FROM
+        );
+
+        if (!$from) {
+            throw new RuntimeException(
+                'No From (source) node in query'
+            );
+        }
+
+        $dispatches = array(
+            QBConstants::NT_FROM,
+            QBConstants::NT_SELECT,
+            QBConstants::NT_WHERE,
+            QBConstants::NT_ORDER_BY,
+        );
+
+        foreach ($dispatches as $dispatchType) {
+            $this->dispatchMany($builder->getChildrenOfType($dispatchType));
+        }
+
+        if (count($this->sourceDocumentNodes) > 1 && null === $builder->getPrimaryAlias()) {
+            throw new \InvalidArgumentException(
+                'You must specify a primary alias when selecting from multiple document sources' .
+                'e.g. $qb->from(\'a\') ...'
+            );
+        }
+
+        $this->applySourceConstraints($builder);
+
+        $phpcrQuery = $this->qomf->createQuery(
+            $this->from,
+            $this->constraint,
+            $this->orderings,
+            $this->columns
+        );
+
+        $query = new Query($phpcrQuery, $this->eventDispatcher, $this->locale, array(), $builder->getPrimaryAlias());
+
+        if ($firstResult = $builder->getFirstResult()) {
+            $query->setFirstResult($firstResult);
+        }
+
+        if ($maxResults = $builder->getMaxResults()) {
+            $query->setMaxResults($maxResults);
+        }
+
+        return $query;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function applySourceConstraints(QueryBuilder $builder)
+    {
+        foreach ($this->sourceDocumentNodes as $sourceDocumentNode) {
+            $metadata = $this->getMetadata($sourceDocumentNode->getDocumentFqn());
+            $constraint = $this->strategy->createSourceConstraint(
+                $this->qomf, 
+                $sourceDocumentNode->getAlias(),
+                $metadata->getClass()
+            );
+
+            if (null === $constraint) {
+                continue;
+            }
+
+            if ($this->constraint) {
+                $this->constraint = $this->qomf->andConstraint(
+                    $this->constraint,
+                    $constraint
+                );
+                continue;
+            }
+
+            $this->constraint = $constraint;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function walkSourceDocument(SourceDocument $node)
+    {
+        $alias = $node->getAlias();
+        $documentFqn = $node->getDocumentFqn();
+
+        $this->sourceDocumentNodes[$alias] = $node;
+
+        $this->documentMetadata[$alias] = $this->getMetadata($documentFqn);
+
+        $alias = $this->qomf->selector(
+            $alias,
+            $this->strategy->getPrimaryNodeType($documentFqn)
+        );
+
+        return $alias;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function walkOperandDynamicField(OperandDynamicField $node)
+    {
+        $alias = $node->getAlias();
+        $field = $node->getField();
+
+        list($alias, $phpcrProperty) = $this->getPhpcrProperty(
+            $alias,
+            $field
+        );
+
+        $operand = $this->qomf->propertyValue(
+            $alias,
+            $phpcrProperty
+        );
+
+        return $operand;
+    }
+
+    /**
+     * Return the PHPCR property name and alias for the given document
+     * field name and query alias.
+     *
+     * @param string $alias As specified in the query source.
+     * @param string $field Name of the document field
+     *
+     * @return array {
+     *     @var string Element is the real alias to use, second element is
+     *     @var string the property name
+     * }
+     */
+    protected function getPhpcrProperty($alias, $field)
+    {
+        if (!isset($this->documentMetadata[$alias])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown document alias "%s". Known aliases: "%s"',
+                $alias,
+                implode('", "', array_keys($this->documentMetadata))
+            ));
+        }
+
+        $metadata = $this->documentMetadata[$alias];
+        $fieldMapping = $metadata->getFieldMapping($field);
+        $phpcrName = $this->encoder->encode(
+            $fieldMapping['encoding'],
+            $fieldMapping['property'],
+            $this->locale
+        );
+
+        return array($alias, $phpcrName);
+    }
+
+    /**
+     * Return either the metadata for the fqn of the document, or the alias
+     *
+     * @param string $documentFqn Document FQN or alias
+     * @return Metadata
+     */
+    protected function getMetadata($documentFqn)
+    {
+        if ($this->metadataFactory->hasAlias($documentFqn)) {
+            return $this->metadataFactory->getMetadataForAlias($documentFqn);
+        }
+
+        return $this->metadataFactory->getMetadataForClass($documentFqn);
+    }
+
+}

--- a/lib/Strategy/MixinStrategy.php
+++ b/lib/Strategy/MixinStrategy.php
@@ -15,6 +15,8 @@ use PHPCR\NodeInterface;
 use PHPCR\Util\UUIDHelper;
 use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 /**
  * Manage nodes via. a jcr mixin.
@@ -66,5 +68,30 @@ class MixinStrategy implements DocumentStrategyInterface
         }
 
         return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPrimaryNodeType($classFqn)
+    {
+        return 'nt:unstructured';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createSourceConstraint(QueryObjectModelFactoryInterface $qomf, $sourceAlias, $classFqn)
+    {
+        $metadata = $this->metadataFactory->getMetadataForClass($classFqn);
+
+        return $qomf->comparison(
+            $qomf->propertyValue(
+                $sourceAlias,
+                'jcr:mixinTypes'
+            ),
+            QOMConstants::JCR_OPERATOR_EQUAL_TO,
+            $qomf->literal($metadata->getPhpcrType())
+        );
     }
 }

--- a/lib/Strategy/MixinStrategy.php
+++ b/lib/Strategy/MixinStrategy.php
@@ -12,11 +12,11 @@
 namespace Sulu\Component\DocumentManager\Strategy;
 
 use PHPCR\NodeInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Util\UUIDHelper;
 use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
-use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 /**
  * Manage nodes via. a jcr mixin.
@@ -71,7 +71,7 @@ class MixinStrategy implements DocumentStrategyInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getPrimaryNodeType($classFqn)
     {
@@ -79,7 +79,7 @@ class MixinStrategy implements DocumentStrategyInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createSourceConstraint(QueryObjectModelFactoryInterface $qomf, $sourceAlias, $classFqn)
     {

--- a/lib/Subscriber/Phpcr/QuerySubscriber.php
+++ b/lib/Subscriber/Phpcr/QuerySubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
 
-use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use PHPCR\Query\QueryInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
@@ -19,8 +18,8 @@ use Sulu\Component\DocumentManager\Event\QueryCreateBuilderEvent;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Events;
-use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
 use Sulu\Component\DocumentManager\Query\Query;
+use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -68,15 +67,15 @@ class QuerySubscriber implements EventSubscriberInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
-        return array(
-            Events::QUERY_CREATE => array('handleCreate', 500),
-            Events::QUERY_CREATE_BUILDER => array('handleCreateBuilder', 500),
-            Events::QUERY_EXECUTE => array('handleQueryExecute', 500),
-        );
+        return [
+            Events::QUERY_CREATE => ['handleCreate', 500],
+            Events::QUERY_CREATE_BUILDER => ['handleCreateBuilder', 500],
+            Events::QUERY_EXECUTE => ['handleQueryExecute', 500],
+        ];
     }
 
     /**

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -59,6 +59,14 @@
             <argument type="service" id="sulu_document_manager.metadata_factory.base"/>
         </service>
 
+        <service id="sulu_document_manager.query.builder_converter" class="Sulu\Component\DocumentManager\Query\QueryBuilderConverter" public="false">
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_document_manager.document_strategy"/>
+        </service>
+
         <!-- Utilities -->
         <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry">
             <argument type="collection">

--- a/symfony-di/subscribers.xml
+++ b/symfony-di/subscribers.xml
@@ -93,6 +93,7 @@
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
             <argument type="service" id="doctrine_phpcr.default_session"/>
             <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument type="service" id="sulu_document_manager.query.builder_converter" />
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -177,13 +177,14 @@ class Bootstrap
         $session = $repository->login($credentials, 'default');
 
         $nodeTypeManager = $session->getWorkspace()->getNodeTypeManager();
-        if (!$nodeTypeManager->hasNodeType('mix:test')) {
-            $nodeTypeManager->registerNodeTypesCnd(<<<EOT
-[mix:test] > mix:referenceable mix
-[mix:mapping5] > mix:referenceable mix
-[mix:mapping10] > mix:referenceable mix
+
+        foreach (['mix:issue', 'mix:test', 'mix:mapping5', 'mix:mapping10'] as $mixinType) {
+            if (!$nodeTypeManager->hasNodeType($mixinType)) {
+                $nodeTypeManager->registerNodeTypesCnd(sprintf(<<<EOT
+    [%s] > mix:referenceable mix
 EOT
-            , true);
+                , $mixinType), true);
+            }
         }
 
         $namespaceRegistry = $session->getWorkspace()->getNamespaceRegistry();

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -95,14 +95,14 @@ class Bootstrap
                     'alias' => 'issue',
                     'phpcr_type' => 'mix:issue',
                     'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\IssueDocument',
-                    'mapping' => array(
-                        'name' => array(
+                    'mapping' => [
+                        'name' => [
                             'encoding' => 'content',
-                        ),
-                        'status' => array(
+                        ],
+                        'status' => [
                             'encoding' => 'content',
-                        ),
-                    ),
+                        ],
+                    ],
                 ],
             ],
             'sulu_document_manager.namespace_mapping' => [

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -91,6 +91,19 @@ class Bootstrap
                         'ten' => [],
                     ],
                 ],
+                'issue' => [
+                    'alias' => 'issue',
+                    'phpcr_type' => 'mix:issue',
+                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\IssueDocument',
+                    'mapping' => array(
+                        'name' => array(
+                            'encoding' => 'content',
+                        ),
+                        'status' => array(
+                            'encoding' => 'content',
+                        ),
+                    ),
+                ],
             ],
             'sulu_document_manager.namespace_mapping' => [
                 'system' => 'nsys',

--- a/tests/Functional/DocumentManager/QueryBuilderTest.php
+++ b/tests/Functional/DocumentManager/QueryBuilderTest.php
@@ -22,7 +22,8 @@ use Sulu\Component\DocumentManager\Tests\Functional\Model\IssueDocument;
  * builder is tested in that package.
  *
  * This class just needs to test the Sulu Converter which converts the query builder object
- * into a PHPCR query.
+ * into a PHPCR query. Testing this as a unit would be very complicated due to having to mock
+ * the PHPCR QOMF.
  */
 class QueryBuilderTest extends BaseTestCase
 {
@@ -248,5 +249,24 @@ class QueryBuilderTest extends BaseTestCase
         $builder->setFirstResult(1);
         $results = $builder->getQuery()->execute();
         $this->assertCount(1, $results->toArray());
+    }
+
+    /**
+     * It should throw an exception if you try and select from multiple sources without
+     * specifying a primary selector.
+     *
+     * @expectedException InvalidArgumentException 
+     * @expectedExceptionMessage You must specify a primary alias when selecting from multiple document sources
+     */
+    public function testMultipleSelectorsNoPrimary()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from()->joinInner()
+            ->left()->document('full', 'f')->end()
+            ->right()->document('issue', 'i')->end()
+            ->condition()->equi('f.status', 'i.status');
+        $builder->where()->eq()->field('i.status')->literal('closed');
+        $builder->getQuery();
     }
 }

--- a/tests/Functional/DocumentManager/QueryBuilderTest.php
+++ b/tests/Functional/DocumentManager/QueryBuilderTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\DocumentManager;
+
+use Sulu\Component\DocumentManager\Tests\Functional\BaseTestCase;
+use Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument;
+use Sulu\Component\DocumentManager\Tests\Functional\Model\IssueDocument;
+
+/**
+ * Query builder tests.
+ *
+ * Note that we currently extend the PHPCR-ODM query builder, so most of the query
+ * builder is tested in that package.
+ *
+ * This class just needs to test the Sulu Converter which converts the query builder object
+ * into a PHPCR query.
+ */
+class QueryBuilderTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->initPhpcr();
+        $manager = $this->getDocumentManager();
+
+        $document1 = $manager->create('full');
+        $document1->setTitle('Hello');
+        $document1->setBody('Hello this is something');
+        $document1->setStatus('open');
+        $manager->persist($document1, 'en', array('path' => '/test/document1', 'auto_create' => true));
+
+        $document2 = $manager->create('full');
+        $document2->setTitle('Goodbye');
+        $document2->setBody('Goodbye and Adios');
+        $document2->setStatus('closed');
+        $document2->setReference($document1);
+        $manager->persist($document2, 'en', array('path' => '/test/document2', 'auto_create' => true));
+
+        $document2->setTitle('Aufweidersehn');
+        $document2->setBody('Gutetag, das ist etwas');
+        $manager->persist($document2, 'de', array('path' => '/test/document2'));
+
+        $issue1 = $manager->create('issue');
+        $issue1->setName('Does it work?');
+        $issue1->setStatus('open');
+        $manager->persist($issue1, null, array(
+            'path' => '/test/issue1',
+            'auto_create' => true,
+        ));
+
+        $issue2 = $manager->create('issue');
+        $issue2->setName('What shall we do today?');
+        $issue2->setStatus('closed');
+
+        $manager->persist($issue2, null, array(
+            'path' => '/test/issue2',
+            'auto_create' => true,
+        ));
+
+        $issue3 = $manager->create('issue');
+        $issue3->setName('The hot water at ten and a closed car at four');
+        $issue3->setStatus('open');
+
+        $manager->persist($issue3, null, array(
+            'path' => '/test/issue3',
+            'auto_create' => true,
+        ));
+
+        $manager->flush();
+    }
+
+    /**
+     * It should query from an alias source.
+     */
+    public function testFromAlias()
+    {
+        $manager = $this->getDocumentManager();
+        $builder = $manager->createQueryBuilder();
+        $builder->setLocale('en');
+        $query = $builder->from()->document('full', 'p')->end()->getQuery();
+        $results = $query->execute();
+        $this->assertGreaterThan(1, count($results));
+    }
+
+    /**
+     * It should query from a class FQN source.
+     */
+    public function testFromDocumentClass()
+    {
+        $manager = $this->getDocumentManager();
+        $builder = $manager->createQueryBuilder();
+        $builder->setLocale('en');
+        $query = $builder->from()->document('Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument', 'p')->end()->getQuery();
+        $results = $query->execute();
+        $this->assertGreaterThan(1, count($results));
+    }
+
+    /**
+     * Test query by field.
+     */
+    public function testQueryByField()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder
+            ->setLocale('en')
+            ->from()
+                ->document('full', 'f')
+            ->end()
+            ->where()
+                ->eq()->field('f.title')->literal('Hello');
+
+        $results = $builder->getQuery()->execute();
+        $this->assertEquals(1, count($results));
+
+        return $builder;
+    }
+
+    /**
+     * It should take the locale into account when querying.
+     *
+     * @depends testQueryByField
+     */
+    public function testQueryByFieldWithLocale($builder)
+    {
+        $builder->setLocale('az');
+
+        $results = $builder->getQuery()->execute();
+        $this->assertEquals(0, count($results));
+    }
+
+    /**
+     * It should query on fields mapped by subscribers.
+     */
+    public function testQueryBySubscriberFields()
+    {
+        $oneHourAgo = new \DateTime();
+        $oneHourAgo->modify('-1 hour');
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder
+            ->setLocale('en')
+            ->from()
+                ->document('full', 'f')
+            ->end()
+            ->where()
+                ->fieldIsset('f.created');
+
+        $results = $builder->getQuery()->execute();
+        $this->assertEquals(2, count($results));
+    }
+
+    /**
+     * It should join sources, hydrating objects from right().
+     */
+    public function testQueryBuilderFromJoinHydrateRight()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from('i')->joinInner()
+            ->left()->document('full', 'f')->end()
+            ->right()->document('issue', 'i')->end()
+            ->condition()->equi('f.status', 'i.status');
+        $builder->where()->eq()->field('i.status')->literal('closed');
+        $results = $builder->getQuery()->execute();
+
+        $this->assertEquals(1, count($results));
+        $this->assertContainsOnlyInstancesOf(IssueDocument::class, $results->toArray());
+    }
+
+    /**
+     * It should join sources hydrating objects from left().
+     */
+    public function testQueryBuilderFromJoinHydrateLeft()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from('f')->joinInner()
+            ->left()->document('full', 'f')->end()
+            ->right()->document('issue', 'i')->end()
+            ->condition()->equi('f.status', 'i.status');
+        $builder->where()->eq()->field('i.status')->literal('closed');
+        $results = $builder->getQuery()->execute();
+
+        $this->assertEquals(1, count($results));
+        $this->assertContainsOnlyInstancesOf(FullDocument::class, $results->toArray());
+    }
+
+    /**
+     * It should throw an exception if the primary alias is not given when selecting from a join.
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testQueryBuilderFromJoinNoPrimary()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from()->joinInner()
+            ->left()->document('full', 'f')->end()
+            ->right()->document('issue', 'i')->end()
+            ->condition()->equi('f.status', 'i.status');
+        $builder->getQuery();
+    }
+
+    /**
+     * It should be able to change locales.
+     */
+    public function testQueryBuilderDifferentLocales()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from()->document('full', 'f');
+        $builder->where()->eq()->field('f.status')->literal('closed');
+
+        $results = $builder->getQuery()->execute();
+        $this->assertEquals('Goodbye', $results->current()->getTitle());
+
+        $builder->setLocale('de');
+        $results = $builder->getQuery()->execute();
+        $this->assertEquals('Aufweidersehn', $results->current()->getTitle());
+    }
+
+    /**
+     * It should limit the results
+     */
+    public function testQueryBuilderLimit()
+    {
+        $builder = $this->getDocumentManager()->createQueryBuilder();
+        $builder->setLocale('en');
+        $builder->from()->document('issue', 'i');
+        $results = $builder->getQuery()->execute();
+        $this->assertCount(3, $results->toArray());
+
+        $builder->setMaxResults(2);
+        $results = $builder->getQuery()->execute();
+        $this->assertCount(2, $results->toArray());
+
+        $builder->setMaxResults(1);
+        $results = $builder->getQuery()->execute();
+        $this->assertCount(1, $results->toArray());
+
+        $builder->setFirstResult(1);
+        $results = $builder->getQuery()->execute();
+        $this->assertCount(1, $results->toArray());
+    }
+}

--- a/tests/Functional/DocumentManager/QueryBuilderTest.php
+++ b/tests/Functional/DocumentManager/QueryBuilderTest.php
@@ -35,44 +35,44 @@ class QueryBuilderTest extends BaseTestCase
         $document1->setTitle('Hello');
         $document1->setBody('Hello this is something');
         $document1->setStatus('open');
-        $manager->persist($document1, 'en', array('path' => '/test/document1', 'auto_create' => true));
+        $manager->persist($document1, 'en', ['path' => '/test/document1', 'auto_create' => true]);
 
         $document2 = $manager->create('full');
         $document2->setTitle('Goodbye');
         $document2->setBody('Goodbye and Adios');
         $document2->setStatus('closed');
         $document2->setReference($document1);
-        $manager->persist($document2, 'en', array('path' => '/test/document2', 'auto_create' => true));
+        $manager->persist($document2, 'en', ['path' => '/test/document2', 'auto_create' => true]);
 
         $document2->setTitle('Aufweidersehn');
         $document2->setBody('Gutetag, das ist etwas');
-        $manager->persist($document2, 'de', array('path' => '/test/document2'));
+        $manager->persist($document2, 'de', ['path' => '/test/document2']);
 
         $issue1 = $manager->create('issue');
         $issue1->setName('Does it work?');
         $issue1->setStatus('open');
-        $manager->persist($issue1, null, array(
+        $manager->persist($issue1, null, [
             'path' => '/test/issue1',
             'auto_create' => true,
-        ));
+        ]);
 
         $issue2 = $manager->create('issue');
         $issue2->setName('What shall we do today?');
         $issue2->setStatus('closed');
 
-        $manager->persist($issue2, null, array(
+        $manager->persist($issue2, null, [
             'path' => '/test/issue2',
             'auto_create' => true,
-        ));
+        ]);
 
         $issue3 = $manager->create('issue');
         $issue3->setName('The hot water at ten and a closed car at four');
         $issue3->setStatus('open');
 
-        $manager->persist($issue3, null, array(
+        $manager->persist($issue3, null, [
             'path' => '/test/issue3',
             'auto_create' => true,
-        ));
+        ]);
 
         $manager->flush();
     }
@@ -227,7 +227,7 @@ class QueryBuilderTest extends BaseTestCase
     }
 
     /**
-     * It should limit the results
+     * It should limit the results.
      */
     public function testQueryBuilderLimit()
     {

--- a/tests/Functional/Model/IssueDocument.php
+++ b/tests/Functional/Model/IssueDocument.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\Model;
+
+/**
+ * Test document representing an issue.
+ */
+class IssueDocument
+{
+    protected $status;
+    protected $name;
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -40,4 +40,17 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
         $this->metadata->setClass('\stdClass');
         $this->assertNotSame($reflection, $this->metadata->getReflectionClass());
     }
+
+    /**
+     * It should return a specific field mapping
+     */
+    public function testGetFieldMapping()
+    {
+        $this->metadata->addFieldMapping('hello', ['property' => 'foo']);
+        $this->assertContains([
+                'property' => 'foo',
+            ],
+            $this->metadata->getFieldMapping('hello')
+        );
+    }
 }

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -55,7 +55,7 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if the given mapping does not exist
+     * It should throw an exception if the given mapping does not exist.
      *
      * @expectedException InvalidArgumentException
      */

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -47,7 +47,8 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
     public function testGetFieldMapping()
     {
         $this->metadata->addFieldMapping('hello', ['property' => 'foo']);
-        $this->assertContains([
+        $this->assertContains(
+            [
                 'property' => 'foo',
             ],
             $this->metadata->getFieldMapping('hello')
@@ -61,10 +62,6 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFieldMappingNonExisting()
     {
-        $this->assertContains([
-                'property' => 'foo',
-            ],
-            $this->metadata->getFieldMapping('hello')
-        );
+        $this->metadata->getFieldMapping('hello');
     }
 }

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -42,7 +42,7 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should return a specific field mapping
+     * It should return a specific field mapping.
      */
     public function testGetFieldMapping()
     {

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -53,4 +53,18 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
             $this->metadata->getFieldMapping('hello')
         );
     }
+
+    /**
+     * It should throw an exception if the given mapping does not exist
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetFieldMappingNonExisting()
+    {
+        $this->assertContains([
+                'property' => 'foo',
+            ],
+            $this->metadata->getFieldMapping('hello')
+        );
+    }
 }

--- a/tests/Unit/Strategy/MixinStrategyTest.php
+++ b/tests/Unit/Strategy/MixinStrategyTest.php
@@ -8,6 +8,11 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Strategy\MixinStrategy;
 use Sulu\Component\DocumentManager\Strategy\Strategy;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Query\QOM\ComparisonInterface;
+use PHPCR\Query\QOM\PropertyValueInterface;
+use PHPCR\Query\QOM\LiteralInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 class MixinStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -65,5 +70,39 @@ class MixinStrategyTest extends \PHPUnit_Framework_TestCase
         $result = $this->strategy->resolveMetadataForNode($this->node->reveal());
 
         $this->assertNull($result);
+    }
+
+    /**
+     * It should return the primary node type for a class fqn
+     * It should always return [nt:unstructured]
+     */
+    public function testGetPrimaryNodeType()
+    {
+        $this->assertEquals('nt:unstructured', $this->strategy->getPrimaryNodeType('foo'));
+        $this->assertEquals('nt:unstructured', $this->strategy->getPrimaryNodeType('bar'));
+    }
+
+    /**
+     * It should create a source constraint for a given document fqn
+     */
+    public function testCreateSourceConstraint()
+    {
+        $qomf = $this->prophesize(QueryObjectModelFactoryInterface::class);
+        $comparison = $this->prophesize(ComparisonInterface::class);
+        $propertyValue = $this->prophesize(PropertyValueInterface::class);
+        $literal = $this->prophesize(LiteralInterface::class);
+        $this->factory->getMetadataForClass('stdClass')->willReturn($this->metadata->reveal());
+        $this->metadata->getPhpcrType()->willReturn('foo:bar');
+
+        $qomf->propertyValue('a', 'jcr:mixinTypes')->willReturn($propertyValue->reveal());
+        $qomf->literal('foo:bar')->willReturn($literal->reveal());
+        $qomf->comparison(
+            $propertyValue->reveal(),
+            QOMConstants::JCR_OPERATOR_EQUAL_TO,
+            $literal->reveal()
+        )->willReturn($comparison->reveal());
+
+        $constraint = $this->strategy->createSourceConstraint($qomf->reveal(), 'a', 'stdClass');
+        $this->assertSame($comparison->reveal(), $constraint);
     }
 }

--- a/tests/Unit/Strategy/MixinStrategyTest.php
+++ b/tests/Unit/Strategy/MixinStrategyTest.php
@@ -3,16 +3,16 @@
 namespace Sulu\Comonent\DocumentManager\tests\Unit\Strategy;
 
 use PHPCR\NodeInterface;
+use PHPCR\Query\QOM\ComparisonInterface;
+use PHPCR\Query\QOM\LiteralInterface;
+use PHPCR\Query\QOM\PropertyValueInterface;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Strategy\MixinStrategy;
 use Sulu\Component\DocumentManager\Strategy\Strategy;
-use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
-use PHPCR\Query\QOM\ComparisonInterface;
-use PHPCR\Query\QOM\PropertyValueInterface;
-use PHPCR\Query\QOM\LiteralInterface;
-use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstants;
 
 class MixinStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,7 +74,7 @@ class MixinStrategyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should return the primary node type for a class fqn
-     * It should always return [nt:unstructured]
+     * It should always return [nt:unstructured].
      */
     public function testGetPrimaryNodeType()
     {
@@ -83,7 +83,7 @@ class MixinStrategyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should create a source constraint for a given document fqn
+     * It should create a source constraint for a given document fqn.
      */
     public function testCreateSourceConstraint()
     {

--- a/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -19,6 +19,7 @@ use PHPCR\WorkspaceInterface;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
 use Sulu\Component\DocumentManager\Query\Query;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -86,10 +87,12 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
         $this->queryCreateEvent = $this->prophesize(QueryCreateEvent::class);
         $this->queryExecuteEvent = $this->prophesize(QueryExecuteEvent::class);
         $this->query = $this->prophesize(Query::class);
+        $this->converter = $this->prophesize(QueryBuilderConverter::class);
 
         $this->subscriber = new QuerySubscriber(
             $this->session->reveal(),
-            $this->dispatcher->reveal()
+            $this->dispatcher->reveal(),
+            $this->converter->reveal()
         );
 
         $this->session->getWorkspace()->willReturn($this->workspace->reveal());
@@ -107,14 +110,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($query);
         $this->queryCreateEvent->getLocale()->willReturn($locale);
-        $this->queryCreateEvent->getOptions()->willReturn([]);
+        $this->queryCreateEvent->getOptions()->willReturn(array());
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($query, 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
-            [],
+            array(),
             $primarySelector
         ))->shouldBeCalled();
 
@@ -131,14 +134,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->getLocale()->willReturn($locale);
-        $this->queryCreateEvent->getOptions()->willReturn([]);
+        $this->queryCreateEvent->getOptions()->willReturn(array());
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($this->phpcrQuery->reveal(), 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
-            [],
+            array(),
             $primarySelector
         ))->shouldBeCalled();
 
@@ -158,13 +161,15 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
         $this->phpcrQuery->execute()->willReturn($this->phpcrResult->reveal());
         $this->query->getPrimarySelector()->willReturn($primarySelector);
         $this->queryExecuteEvent->getQuery()->willReturn($this->query->reveal());
-        $this->queryExecuteEvent->getOptions()->willReturn([]);
+        $this->queryExecuteEvent->getOptions()->willReturn(array());
 
         $this->queryExecuteEvent->setResult(
             new QueryResultCollection(
                 $this->phpcrResult->reveal(),
                 $this->dispatcher->reveal(),
-                $locale
+                $locale,
+                array(),
+                $primarySelector
             )
         )->shouldBeCalled();
 

--- a/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -19,8 +19,8 @@ use PHPCR\WorkspaceInterface;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
-use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
 use Sulu\Component\DocumentManager\Query\Query;
+use Sulu\Component\DocumentManager\Query\QueryBuilderConverter;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -110,14 +110,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($query);
         $this->queryCreateEvent->getLocale()->willReturn($locale);
-        $this->queryCreateEvent->getOptions()->willReturn(array());
+        $this->queryCreateEvent->getOptions()->willReturn([]);
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($query, 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
-            array(),
+            [],
             $primarySelector
         ))->shouldBeCalled();
 
@@ -134,14 +134,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->queryCreateEvent->getInnerQuery()->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->getLocale()->willReturn($locale);
-        $this->queryCreateEvent->getOptions()->willReturn(array());
+        $this->queryCreateEvent->getOptions()->willReturn([]);
         $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
         $this->queryManager->createQuery($this->phpcrQuery->reveal(), 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
         $this->queryCreateEvent->setQuery(new Query(
             $this->phpcrQuery->reveal(),
             $this->dispatcher->reveal(),
             $locale,
-            array(),
+            [],
             $primarySelector
         ))->shouldBeCalled();
 
@@ -161,14 +161,14 @@ class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
         $this->phpcrQuery->execute()->willReturn($this->phpcrResult->reveal());
         $this->query->getPrimarySelector()->willReturn($primarySelector);
         $this->queryExecuteEvent->getQuery()->willReturn($this->query->reveal());
-        $this->queryExecuteEvent->getOptions()->willReturn(array());
+        $this->queryExecuteEvent->getOptions()->willReturn([]);
 
         $this->queryExecuteEvent->setResult(
             new QueryResultCollection(
                 $this->phpcrResult->reveal(),
                 $this->dispatcher->reveal(),
                 $locale,
-                array(),
+                [],
                 $primarySelector
             )
         )->shouldBeCalled();


### PR DESCRIPTION
This PR implements the query builder. The code has been ported from the earlier, abandoned, metadata PR.

Example using a join:

``` php
    $builder = $this->getDocumentManager()->createQueryBuilder();
    $builder->setLocale('en');
    $builder->from('i')->joinInner()
        ->left()->document('full', 'f')->end()
        ->right()->document('issue', 'i')->end()
        ->condition()->equi('f.status', 'i.status')
        ->where()->eq()->field('i.status')->literal('closed');
    $results = $builder->getQuery()->execute();
```

It is uses the PHPCR-ODM query builder and introduces a "converter" to translate integrate the query builder with the Sulu Document Manager.

Note that this PR does not include any specific Sulu Content functionality. That will be introduced in a follow up PR on the sulu-io/sulu repository.

This PR depends on the imminent PHPCR-ODM 1.3 release.
