### PR TITLE
Fixed undefined ghost title

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,8 +7,7 @@ enabled:
 
 disabled:
     - concat_without_spaces
+    - phpdoc_align
     - phpdoc_indent
-    - phpdoc_params
     - phpdoc_to_comment
     - blankline_after_open_tag
-    - psr0

--- a/lib/DocumentStrategyInterface.php
+++ b/lib/DocumentStrategyInterface.php
@@ -45,7 +45,7 @@ interface DocumentStrategyInterface
      *
      * @param NodeInterface $node
      *
-     * @return Metadata|NULL
+     * @return Metadata|null
      */
     public function resolveMetadataForNode(NodeInterface $node);
 }

--- a/lib/ProxyFactory.php
+++ b/lib/ProxyFactory.php
@@ -71,10 +71,11 @@ class ProxyFactory
      *
      * @param object $fromDocument
      * @param NodeInterface $targetNode
+     * @param array $options
      *
      * @return \ProxyManager\Proxy\GhostObjectInterface
      */
-    public function createProxyForNode($fromDocument, NodeInterface $targetNode)
+    public function createProxyForNode($fromDocument, NodeInterface $targetNode, $options = [])
     {
         // if node is already registered then just return the registered document
         if ($this->registry->hasNode($targetNode)) {
@@ -93,11 +94,12 @@ class ProxyFactory
 
         $initializer = function (LazyLoadingInterface $document, $method, array $parameters, &$initializer) use (
             $fromDocument,
-            $targetNode
+            $targetNode,
+            $options
         ) {
             $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
 
-            $hydrateEvent = new HydrateEvent($targetNode, $locale);
+            $hydrateEvent = new HydrateEvent($targetNode, $locale, $options);
             $hydrateEvent->setDocument($document);
             $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
 

--- a/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
+++ b/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
@@ -14,7 +14,6 @@ namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
 use PHPCR\NodeInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\DocumentInspector;
-use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\MoveEvent;
@@ -81,7 +80,7 @@ class ParentSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
         $node = $this->inspector->getNode($event->getDocument());
-        $this->mapParent($document, $node);
+        $this->mapParent($document, $node, $event->getOptions());
     }
 
     /**
@@ -151,7 +150,14 @@ class ParentSubscriber implements EventSubscriberInterface
         $this->documentManager->move($document, $parentNode->getPath());
     }
 
-    private function mapParent($document, NodeInterface $node)
+    /**
+     * Map parent document to given document.
+     *
+     * @param object $document child-document
+     * @param NodeInterface $node to determine parent
+     * @param array $options options to load parent
+     */
+    private function mapParent($document, NodeInterface $node, $options = [])
     {
         // TODO: performance warning: We are eagerly fetching the parent node
         $targetNode = $node->getParent();
@@ -161,6 +167,6 @@ class ParentSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $document->setParent($this->proxyFactory->createProxyForNode($document, $targetNode));
+        $document->setParent($this->proxyFactory->createProxyForNode($document, $targetNode, $options));
     }
 }

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -211,8 +211,8 @@ class RegistratorSubscriber implements EventSubscriberInterface
         $this->documentRegistry->clear();
     }
 
-    /*
-     * Register the document and apparently update the locale --
+    /**
+     * Register the document and apparently update the locale --.
      *
      * TODO: Is locale handling already done above??
      *

--- a/tests/Bench/PathBuilderBench.php
+++ b/tests/Bench/PathBuilderBench.php
@@ -21,6 +21,7 @@ class PathBuilderBench implements Benchmark
         ]);
         $this->pathBuilder = new PathBuilder($registry);
     }
+
     /**
      * @description Build path 1000 times
      * @revs 1000

--- a/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
@@ -61,7 +61,8 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->node->getParent()->willReturn($this->parentNode->reveal());
         $this->node->getDepth()->willReturn(2);
 
-        $this->proxyFactory->createProxyForNode($this->document, $this->parentNode->reveal())->willReturn($this->parentDocument);
+        $this->proxyFactory->createProxyForNode($this->document, $this->parentNode->reveal(), [])
+            ->willReturn($this->parentDocument);
         $this->parentNode->hasProperty('jcr:uuid')->willReturn(true);
 
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());


### PR DESCRIPTION
Often in sulu the title of ghost pages is undefined. The proxy-factory uses different options (`[]`) to load childs then parent.

**tasks:**
- [x] test coverage
- [ ] gather feedback for my changes

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | none |
| BC breaks | none |
| Documentation PR | none |
