### PR TITLE
Fixed document different locale

### DIFF
--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\DocumentManager\tests\Functional;
 
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Tests\Bootstrap;
 
 abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
@@ -46,6 +47,9 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
         return $this->container;
     }
 
+    /**
+     * @return DocumentManagerInterface
+     */
     protected function getDocumentManager()
     {
         return $this->getContainer()->get('sulu_document_manager.document_manager');

--- a/tests/Functional/DocumentManager/FindTest.php
+++ b/tests/Functional/DocumentManager/FindTest.php
@@ -74,4 +74,26 @@ class FindTest extends BaseTestCase
         $document = $persistedDocument;
         $this->assertEquals('en', $document->getLocale());
     }
+
+    /**
+     * It can load different locales from the same document in the same request.
+     */
+    public function testFindMultipleDifferentLocales()
+    {
+        $this->generateDataSet([
+            'locales' => ['en', 'de'],
+        ]);
+
+        $manager = $this->getDocumentManager();
+        $manager->flush();
+
+        $result1 = $manager->find(self::BASE_PATH, 'en');
+        $this->assertEquals('en', $result1->getLocale());
+
+        $result2 = $manager->find(self::BASE_PATH, 'de');
+        $this->assertEquals('de', $result2->getLocale());
+
+        $this->assertNotEquals(false, $result1 === $result2);
+        $this->assertEquals('en', $result1->getLocale());
+    }
 }


### PR DESCRIPTION
For different locales the document manager did not return different objects. so you can overwrite properties of a document which could be used somewhere else without knowing ...

The easiest way would be to handle the locale in the `DocumentRegistry`. there is one document for a node in english and one in german for example. 

**tasks:**
- [ ] test coverage
- [ ] gather feedback for my changes
- [ ] submit changes to the documentation

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | #41 |
| BC breaks | none |
| Documentation PR | none |
