### PR TITLE
Rehydrate option

### DIFF
--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -14,13 +14,13 @@ namespace Sulu\Component\DocumentManager\Subscriber\Core;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 
 /**
  * Responsible for registering and deregistering documents and PHPCR nodes

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -67,6 +67,9 @@ class RegistratorSubscriber implements EventSubscriberInterface
         ];
     }
 
+    /**
+     * @param ConfigureOptionsEvent $event
+     */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
         $options = $event->getOptions();

--- a/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -70,6 +70,25 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->hasDocument()->willReturn(false);
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->hydrateEvent->getOptions()->willReturn(array());
+        $this->registry->hasNode($this->node->reveal())->willReturn(true);
+        $this->registry->getDocumentForNode($this->node->reveal())->willReturn($this->document);
+        $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();
+        $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should halt propagation if the document is already in the registry and the "rehydrate" option is false.
+     */
+    public function testDocumentFromRegistryNoRehydration()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(false);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->hydrateEvent->getOptions()->willReturn([
+            'rehydrate' => false,
+        ]);
+        $this->hydrateEvent->stopPropagation()->shouldBeCalled();
         $this->registry->hasNode($this->node->reveal())->willReturn(true);
         $this->registry->getDocumentForNode($this->node->reveal())->willReturn($this->document);
         $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();

--- a/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -70,7 +70,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->hasDocument()->willReturn(false);
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('fr');
-        $this->hydrateEvent->getOptions()->willReturn(array());
+        $this->hydrateEvent->getOptions()->willReturn([]);
         $this->registry->hasNode($this->node->reveal())->willReturn(true);
         $this->registry->getDocumentForNode($this->node->reveal())->willReturn($this->document);
         $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();


### PR DESCRIPTION
Added an option to disable "rehydration" of a document which is already in the document registry.

The behavior is as follows:
- If `rehydrate` is false, then `RegistationSubscriber::handleDocumentFromRegistry` method will stop further event propagation if the document is already in the registry.

This allows the document to be retrieved from the document manager without changing it's global state.
