### PR TITLE
fixed tests for ParentSubscriber

### DIFF
--- a/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
+++ b/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
@@ -80,7 +80,7 @@ class ParentSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
         $node = $this->inspector->getNode($event->getDocument());
-        $this->mapParent($document, $node, $event->getOptions());
+        $this->mapParent($document, $node);
     }
 
     /**

--- a/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Sulu CMS.
+ * This file is part of Sulu.
  *
  * (c) MASSIVE ART WebServices GmbH
  *
@@ -12,19 +12,77 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
+use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber;
 
 class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var MoveEvent
+     */
+    private $moveEvent;
+
+    /**
+     * @var ParentBehavior
+     */
+    private $document;
+
+    /**
+     * @var \stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var \stdClass
+     */
+    private $parentDocument;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $inspector;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var ParentSubscriber
+     */
+    private $subscriber;
+
     public function setUp()
     {
         $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
-        $this->document = new TestParentDocument();
+        $this->moveEvent = $this->prophesize(MoveEvent::class);
+        $this->document = $this->prophesize(ParentBehavior::class);
         $this->notImplementing = new \stdClass();
         $this->node = $this->prophesize(NodeInterface::class);
         $this->parentNode = $this->prophesize(NodeInterface::class);
@@ -56,17 +114,18 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydrateParent()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
 
         $this->node->getParent()->willReturn($this->parentNode->reveal());
         $this->node->getDepth()->willReturn(2);
 
-        $this->proxyFactory->createProxyForNode($this->document, $this->parentNode->reveal(), [])
+        $this->proxyFactory->createProxyForNode($this->document->reveal(), $this->parentNode->reveal(), [])
             ->willReturn($this->parentDocument);
         $this->parentNode->hasProperty('jcr:uuid')->willReturn(true);
 
+        $this->document->setParent($this->parentDocument)->shouldBeCalled();
+
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
-        $this->assertSame($this->parentDocument, $this->document->getParent());
     }
 
     /**
@@ -74,7 +133,7 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydrateParentNoUuid()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
         $this->node->getParent()->willReturn($this->parentNode->reveal());
         $this->node->getDepth()->willReturn(2);
         $this->parentNode->hasProperty('jcr:uuid')->willReturn(false);
@@ -85,30 +144,27 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * It should throw an exception if the node for the document is a root node.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testThrowExceptionRootNode()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
 
         $this->node->getParent()->willReturn($this->parentNode->reveal());
         $this->node->getDepth()->willReturn(0);
 
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
     }
-}
 
-class TestParentDocument implements ParentBehavior
-{
-    private $parent;
-
-    public function getParent()
+    public function testMove()
     {
-        return $this->parent;
-    }
+        $this->moveEvent->getDocument()->willReturn($this->document);
+        $this->inspector->getNode($this->document)->willReturn($this->node);
 
-    public function setParent($parent)
-    {
-        $this->parent = $parent;
+        $this->node->getParent()->willReturn($this->parentNode);
+        $this->parentNode->hasProperty('jcr:uuid')->willReturn(true);
+        $this->document->setParent(Argument::any())->shouldBeCalled();
+
+        $this->subscriber->handleMove($this->moveEvent->reveal());
     }
 }


### PR DESCRIPTION
The tests of Sulu were failing. Added a test here to reproduce, and fixed the issue.

**tasks:**
- [x] test coverage
- [x] gather feedback for my changes
- [x] submit changes to the documentation

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | none |
| BC breaks | none |
| Documentation PR | none |
