### PR TITLE
Fixed empty locale when generating property names

### DIFF
--- a/lib/Exception/InvalidLocaleException.php
+++ b/lib/Exception/InvalidLocaleException.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+/**
+ * Indicates invalid locale argument.
+ */
+class InvalidLocaleException extends \InvalidArgumentException
+{
+    /**
+     * @var string
+     */
+    private $locale;
+
+    public function __construct($locale)
+    {
+        parent::__construct(sprintf('Invalid locale "%s"', $locale));
+
+        $this->locale = $locale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+}

--- a/lib/PropertyEncoder.php
+++ b/lib/PropertyEncoder.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\DocumentManager;
 
+use Sulu\Component\DocumentManager\Exception\InvalidLocaleException;
+
 /**
  * Class responsible for encoding properties to PHPCR nodes.
  */
@@ -56,9 +58,7 @@ class PropertyEncoder
     public function localizedSystemName($name, $locale)
     {
         if ($locale === null) {
-            throw new \InvalidArgumentException(sprintf(
-                'Invalid locale "%s"', $locale
-            ));
+            throw new InvalidLocaleException($locale);
         }
 
         return $this->formatLocalizedName('system_localized', $name, $locale);
@@ -83,9 +83,7 @@ class PropertyEncoder
     public function localizedContentName($name, $locale)
     {
         if ($locale === null) {
-            throw new \InvalidArgumentException(sprintf(
-                'Invalid locale "%s"', $locale
-            ));
+            throw new InvalidLocaleException($locale);
         }
 
         return $this->formatLocalizedName('content_localized', $name, $locale);

--- a/lib/PropertyEncoder.php
+++ b/lib/PropertyEncoder.php
@@ -55,6 +55,12 @@ class PropertyEncoder
      */
     public function localizedSystemName($name, $locale)
     {
+        if ($locale === null) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid locale "%s"', $locale
+            ));
+        }
+
         return $this->formatLocalizedName('system_localized', $name, $locale);
     }
 
@@ -76,6 +82,12 @@ class PropertyEncoder
      */
     public function localizedContentName($name, $locale)
     {
+        if ($locale === null) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid locale "%s"', $locale
+            ));
+        }
+
         return $this->formatLocalizedName('content_localized', $name, $locale);
     }
 

--- a/tests/Unit/PropertyEncoderTest.php
+++ b/tests/Unit/PropertyEncoderTest.php
@@ -17,6 +17,16 @@ use Sulu\Component\DocumentManager\PropertyEncoder;
 
 class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
     public function setUp()
     {
         $map = [
@@ -47,5 +57,45 @@ class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $name = $this->encoder->systemName('created');
         $this->assertEquals('nsys:created', $name);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testEncodeLocalizedSystemEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('system_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testEncodeLocalizedContentEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('content_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testLocalizedContentEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('content_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testLocalizedSystemEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('system_localized', 'test', null);
     }
 }


### PR DESCRIPTION
**tasks:**
- [x] test coverage
- [ ] gather feedback for my changes

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | fixes https://github.com/sulu-io/sulu/issues/1704 |
| BC breaks | none |
| Documentation PR | none |
