### PR TITLE
added auto_name option to deactivate renaming of nodes in certain situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * FEATURE #56 added auto_name option to deactivate renaming of nodes in certain situations
+
 * 0.5.0 (2015-12-01)
     * BUGFIX #55 Added rehydrate option to stop propagation listener
 


### PR DESCRIPTION
**tasks:**
- [x] test coverage

**informations:**

| q | a |
| --- | --- |
| Fixed tickets | none |
| Related PRs | TODO |
| BC breaks | none |
| Documentation PR | none |
