### PR TITLE
Added options for remove events

### DIFF
--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -72,9 +72,11 @@ class DocumentManager implements DocumentManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($document)
+    public function remove($document, array $options = [])
     {
-        $event = new Event\RemoveEvent($document);
+        $options = $this->getOptionsResolver(Events::REMOVE)->resolve($options);
+
+        $event = new Event\RemoveEvent($document, $options);
         $this->eventDispatcher->dispatch(Events::REMOVE, $event);
     }
 
@@ -161,14 +163,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     private function getOptionsResolver($eventName)
     {
-        if (isset($this->optionsResolvers[$eventName])) {
+        if (array_key_exists($eventName, $this->optionsResolvers)) {
             return $this->optionsResolvers[$eventName];
         }
 
         $resolver = new OptionsResolver();
         $resolver->setDefault('locale', null);
 
-        $event = new Event\ConfigureOptionsEvent($resolver);
+        $event = new Event\ConfigureOptionsEvent($resolver, $eventName);
         $this->eventDispatcher->dispatch(Events::CONFIGURE_OPTIONS, $event);
 
         $this->optionsResolvers[$eventName] = $resolver;

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -53,8 +53,9 @@ interface DocumentManagerInterface
      * session.
      *
      * @param object $document
+     * @param array $options
      */
-    public function remove($document);
+    public function remove($document, array $options = []);
 
     /**
      * Move the PHPCR node to which the document is mapped to be a child of the node at the given path or UUID.

--- a/lib/Event/ConfigureOptionsEvent.php
+++ b/lib/Event/ConfigureOptionsEvent.php
@@ -18,10 +18,27 @@ class ConfigureOptionsEvent extends AbstractEvent
     use EventOptionsTrait;
 
     /**
-     * @param OptionsResolver $options
+     * @var string
      */
-    public function __construct(OptionsResolver $options)
+    private $eventName;
+
+    /**
+     * @param OptionsResolver $options
+     * @param string $eventName
+     */
+    public function __construct(OptionsResolver $options, $eventName)
     {
         $this->options = $options;
+        $this->eventName = $eventName;
+    }
+
+    /**
+     * Returns event to configure options.
+     *
+     * @return string
+     */
+    public function getEventName()
+    {
+        return $this->eventName;
     }
 }

--- a/lib/Event/RemoveEvent.php
+++ b/lib/Event/RemoveEvent.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Sulu.
  *
@@ -13,4 +12,12 @@ namespace Sulu\Component\DocumentManager\Event;
 
 class RemoveEvent extends AbstractDocumentEvent
 {
+    use EventOptionsTrait;
+
+    public function __construct($document, array $options = [])
+    {
+        parent::__construct($document);
+
+        $this->options = $options;
+    }
 }

--- a/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -95,6 +95,10 @@ class AutoNameSubscriber implements EventSubscriberInterface
 
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $event->getOptions()->setDefaults(
             [
                 'auto_name' => true,

--- a/lib/Subscriber/Behavior/Path/ExplicitSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/ExplicitSubscriber.php
@@ -67,6 +67,10 @@ class ExplicitSubscriber implements EventSubscriberInterface
      */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $options = $event->getOptions();
         $options->setDefaults([
             'path' => null,

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -36,9 +36,8 @@ class RegistratorSubscriber implements EventSubscriberInterface
     /**
      * @param DocumentRegistry $documentRegistry
      */
-    public function __construct(
-        DocumentRegistry $documentRegistry
-    ) {
+    public function __construct(DocumentRegistry $documentRegistry)
+    {
         $this->documentRegistry = $documentRegistry;
     }
 
@@ -72,6 +71,10 @@ class RegistratorSubscriber implements EventSubscriberInterface
      */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $options = $event->getOptions();
         $options->setDefaults([
             'rehydrate' => true,

--- a/lib/Subscriber/Phpcr/FindSubscriber.php
+++ b/lib/Subscriber/Phpcr/FindSubscriber.php
@@ -73,6 +73,10 @@ class FindSubscriber implements EventSubscriberInterface
      */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $options = $event->getOptions();
         $options->setDefaults([
             'type' => null,

--- a/tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
@@ -15,6 +15,7 @@ use PHPCR\NodeInterface;
 use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\ExplicitSubscriber;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,6 +29,7 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->nodeManager = $this->prophesize(NodeManager::class);
         $this->strategy = $this->prophesize(DocumentStrategyInterface::class);
         $this->configureEvent = $this->prophesize(ConfigureOptionsEvent::class);
+        $this->configureEvent->getEventName()->willReturn(Events::PERSIST);
         $this->parentNode = $this->prophesize(NodeInterface::class);
         $this->node = $this->prophesize(NodeInterface::class);
 
@@ -40,7 +42,7 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * It should throw an exception if both path name and node_name options are given.
      *
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testExceptionNodeNameAndPath()
     {
@@ -55,7 +57,7 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * It should throw an exception if both path name and parent_path options are given.
      *
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testExceptionParentPathAndPath()
     {
@@ -127,7 +129,7 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * It should throw an exception if node_name is specified but no parent node is available.
      *
-     * @expectedException Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     * @expectedException \Sulu\Component\DocumentManager\Exception\DocumentManagerException
      */
     public function testNodeNameButNotParentNode()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | none |
| Related issues/PRs | https://github.com/sulu-io/sulu/pull/2115 |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

This PR adds the possibility to pass options into the remove events. they could be used for example to determine which part of the document should be removed.
#### To Do
- [ ] Check if the documentation if valid
- [ ] CHANGELOG
