### PR TITLE
Added name option

### DIFF
--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager;
 
 use PHPCR\SessionInterface;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,6 +26,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * This class is therefore an event dispatcher and a service container and has
  * no other business logic within it.
+ *
+ * All primary methods are wrapped in a try catch block, the exception is then
+ * wrapped in a `DocumentManagerException` with a reference to this document
+ * managers name.
+ *
+ * TODO: Create a proxy document manager which automatically wraps all calls.
  */
 class DocumentManager implements DocumentManagerInterface
 {
@@ -68,6 +75,11 @@ class DocumentManager implements DocumentManagerInterface
      */
     private $session;
 
+    /**
+     * @var string
+     */
+    private $name = 'default';
+
     public function __construct(
         SessionInterface $session,
         EventDispatcherInterface $eventDispatcher,
@@ -98,16 +110,31 @@ class DocumentManager implements DocumentManagerInterface
     }
 
     /**
+     * Attach a name to this document manager (used to indicate the origin of
+     * any exceptions thrown within this domain).
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function find($identifier, $locale = null, array $options = [])
     {
-        $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
+        try {
+            $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
 
-        $event = new Event\FindEvent($this, $identifier, $locale, $options);
-        $this->eventDispatcher->dispatch(Events::FIND, $event);
+            $event = new Event\FindEvent($this, $identifier, $locale, $options);
+            $this->eventDispatcher->dispatch(Events::FIND, $event);
 
-        return $event->getDocument();
+            return $event->getDocument();
+        } catch (\Exception $e) {
+            $this->processException($e, 'finding document');
+        }
     }
 
     /**
@@ -115,10 +142,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function create($alias)
     {
-        $event = new Event\CreateEvent($this, $alias);
-        $this->eventDispatcher->dispatch(Events::CREATE, $event);
+        try {
+            $event = new Event\CreateEvent($this, $alias);
+            $this->eventDispatcher->dispatch(Events::CREATE, $event);
 
-        return $event->getDocument();
+            return $event->getDocument();
+        } catch (\Exception $e) {
+            $this->processException($e, 'creating document');
+        }
     }
 
     /**
@@ -126,10 +157,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function persist($document, $locale = null, array $options = [])
     {
-        $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
+        try {
+            $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
 
-        $event = new Event\PersistEvent($this, $document, $locale, $options);
-        $this->eventDispatcher->dispatch(Events::PERSIST, $event);
+            $event = new Event\PersistEvent($this, $document, $locale, $options);
+            $this->eventDispatcher->dispatch(Events::PERSIST, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'persisting document');
+        }
     }
 
     /**
@@ -137,8 +172,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function remove($document)
     {
-        $event = new Event\RemoveEvent($this, $document);
-        $this->eventDispatcher->dispatch(Events::REMOVE, $event);
+        try {
+            $event = new Event\RemoveEvent($this, $document);
+            $this->eventDispatcher->dispatch(Events::REMOVE, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'removing document');
+        }
     }
 
     /**
@@ -146,8 +185,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function move($document, $destId)
     {
-        $event = new Event\MoveEvent($this, $document, $destId);
-        $this->eventDispatcher->dispatch(Events::MOVE, $event);
+        try {
+            $event = new Event\MoveEvent($this, $document, $destId);
+            $this->eventDispatcher->dispatch(Events::MOVE, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'moving document');
+        }
     }
 
     /**
@@ -155,10 +198,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function copy($document, $destPath)
     {
-        $event = new Event\CopyEvent($this, $document, $destPath);
-        $this->eventDispatcher->dispatch(Events::COPY, $event);
+        try {
+            $event = new Event\CopyEvent($this, $document, $destPath);
+            $this->eventDispatcher->dispatch(Events::COPY, $event);
 
-        return $event->getCopiedPath();
+            return $event->getCopiedPath();
+        } catch (\Exception $e) {
+            $this->processException($e, 'copying document');
+        }
     }
 
     /**
@@ -166,8 +213,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function reorder($document, $destId, $after = false)
     {
-        $event = new Event\ReorderEvent($this, $document, $destId, $after);
-        $this->eventDispatcher->dispatch(Events::REORDER, $event);
+        try {
+            $event = new Event\ReorderEvent($this, $document, $destId, $after);
+            $this->eventDispatcher->dispatch(Events::REORDER, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'reordering document');
+        }
     }
 
     /**
@@ -175,8 +226,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function refresh($document)
     {
-        $event = new Event\RefreshEvent($this, $document);
-        $this->eventDispatcher->dispatch(Events::REFRESH, $event);
+        try {
+            $event = new Event\RefreshEvent($this, $document);
+            $this->eventDispatcher->dispatch(Events::REFRESH, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'refreshing document');
+        }
     }
 
     /**
@@ -184,8 +239,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function flush()
     {
-        $event = new Event\FlushEvent($this);
-        $this->eventDispatcher->dispatch(Events::FLUSH, $event);
+        try {
+            $event = new Event\FlushEvent($this);
+            $this->eventDispatcher->dispatch(Events::FLUSH, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'flushing document manager');
+        }
     }
 
     /**
@@ -193,8 +252,12 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function clear()
     {
-        $event = new Event\ClearEvent($this, $this);
-        $this->eventDispatcher->dispatch(Events::CLEAR, $event);
+        try {
+            $event = new Event\ClearEvent($this, $this);
+            $this->eventDispatcher->dispatch(Events::CLEAR, $event);
+        } catch (\Exception $e) {
+            $this->processException($e, 'clearing document manager');
+        }
     }
 
     /**
@@ -202,10 +265,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function createQuery($query, $locale = null, array $options = [])
     {
-        $event = new Event\QueryCreateEvent($this, $query, $locale, $options);
-        $this->eventDispatcher->dispatch(Events::QUERY_CREATE, $event);
+        try {
+            $event = new Event\QueryCreateEvent($this, $query, $locale, $options);
+            $this->eventDispatcher->dispatch(Events::QUERY_CREATE, $event);
 
-        return $event->getQuery();
+            return $event->getQuery();
+        } catch (\Exception $e) {
+            $this->processException($e, 'creating query');
+        }
     }
 
     /**
@@ -213,10 +280,14 @@ class DocumentManager implements DocumentManagerInterface
      */
     public function createQueryBuilder()
     {
-        $event = new Event\QueryCreateBuilderEvent($this);
-        $this->eventDispatcher->dispatch(Events::QUERY_CREATE_BUILDER, $event);
+        try {
+            $event = new Event\QueryCreateBuilderEvent($this);
+            $this->eventDispatcher->dispatch(Events::QUERY_CREATE_BUILDER, $event);
 
-        return $event->getQueryBuilder();
+            return $event->getQueryBuilder();
+        } catch (\Exception $e) {
+            $this->processException($e, 'creating query builder');
+        }
     }
 
     /**
@@ -293,5 +364,27 @@ class DocumentManager implements DocumentManagerInterface
         $this->optionsResolvers[$eventName] = $resolver;
 
         return $resolver;
+    }
+
+    /**
+     * If the exception is already an instanceof `DocumentManagerException`
+     * (e.g. a `DocumentNotFoundException`) only set the name of the document
+     * manager, otherwise wrap the \Exception in a DocumentManagerException.
+     *
+     * @param \Exception $e
+     * @param string $context
+     */
+    private function processException(\Exception $exception, $context)
+    {
+        if ($exception instanceof DocumentManagerException) {
+            $exception->setDocumentManagerName($this->name);
+            throw $exception;
+        }
+
+        throw new DocumentManagerException(
+            sprintf('Error %s', $context),
+            $this->name,
+            $exception
+        );
     }
 }

--- a/lib/Exception/DocumentManagerException.php
+++ b/lib/Exception/DocumentManagerException.php
@@ -11,6 +11,59 @@
 
 namespace Sulu\Component\DocumentManager\Exception;
 
+/**
+ * Domain exception for the document manager.
+ */
 class DocumentManagerException extends \Exception
 {
+    private $documentManagerName;
+
+    /**
+     * @param string $message
+     * @param string $documentManagerName
+     * @param \Exception $previousException
+     */
+    public function __construct($message, $documentManagerName = null, \Exception $previousException = null)
+    {
+        parent::__construct($message, null, $previousException);
+
+        if ($documentManagerName) {
+            $this->formatMessage($documentManagerName);
+        }
+    }
+
+    /**
+     * Set the name of the document manager which threw this exception.
+     *
+     * @param string $name
+     */
+    public function setDocumentManagerName($name)
+    {
+        $this->formatMessage($name);
+    }
+
+    /**
+     * Return the name of the document manager which threw this exception.
+     *
+     * @return string
+     */
+    public function getDocumentManagerName()
+    {
+        return $this->documentManagerName;
+    }
+
+    /**
+     * Prefix the document manager name to the message.
+     *
+     * @param string $name
+     */
+    private function formatMessage($name)
+    {
+        if ($this->documentManagerName) {
+            throw new \RuntimeException('Cannot set the document manager name as it has already been set in the constructor.');
+        }
+
+        $this->message = sprintf('[%s] %s', $name, $this->message);
+        $this->documentManagerName = $name;
+    }
 }

--- a/lib/Subscriber/Core/MappingSubscriber.php
+++ b/lib/Subscriber/Core/MappingSubscriber.php
@@ -267,15 +267,15 @@ class MappingSubscriber implements EventSubscriberInterface
             );
 
             try {
-            if ($referencedNode) {
-                $accessor->set(
+                if ($referencedNode) {
+                    $accessor->set(
                     $fieldName,
                     $proxyFactory->createProxyForNode($document, $referencedNode, $options)
                 );
-            }
+                }
             } catch (\Exception $e) {
                 throw new \Exception(sprintf(
-                    'Error hydrating proxy relation "%s" for document "%s"', 
+                    'Error hydrating proxy relation "%s" for document "%s"',
                     $fieldName,
                     get_class($document)
                 ), null, $e);

--- a/tests/Unit/Exception/DocumentManagerExceptionTest.php
+++ b/tests/Unit/Exception/DocumentManagerExceptionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Exception;
+
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+class DocumentManagerExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * It should prefix the document manager name.
+     * It should return the name of the document manager.
+     */
+    public function testPrefixDocumentManagerName()
+    {
+        $exception = new DocumentManagerException('Hello', 'foo');
+        $this->assertEquals('[foo] Hello', $exception->getMessage());
+        $this->assertEquals('foo', $exception->getDocumentManagerName());
+    }
+
+    /**
+     * It should allow the document manager name to be set via. a setter.
+     */
+    public function testSetDocumentManagername()
+    {
+        $exception = new DocumentManagerException('Hello');
+        $exception->setDocumentManagerName('foo');
+        $this->assertEquals('[foo] Hello', $exception->getMessage());
+    }
+
+    /**
+     * It should not prefix a name if no name is given.
+     */
+    public function testNoDocumentManagerName()
+    {
+        $exception = new DocumentManagerException('Hello');
+        $this->assertEquals('Hello', $exception->getMessage());
+    }
+
+    /**
+     * It should throw an exception if the document manager name is set twice.
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testSetNameTwice()
+    {
+        $exception = new DocumentManagerException('Hello', 'foo');
+        $exception->setDocumentManagerName('foo');
+    }
+}


### PR DESCRIPTION
This PR allows document managers to be identified with a name and any exceptions thrown through the primary API methods will be either wrapped with a `DocumentManagerException`.

If the Exception is already an instance of `DocumentManagerException` (f.e. a `DocumentNotFoundException`) then the document name will be set on that exception itself.
