### PR TITLE
Introduced mandatory locale in document-registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist 
+    * HOTFIX      #82 Introduced mandatory locale in document-registry
+    * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist
 
 * 0.6.0 (2016-04-11)
     * ENHANCEMENT #58 Added behavior to save unlocalized timestamps and added json_array mapping type

--- a/lib/Behavior/Mapping/LocaleBehavior.php
+++ b/lib/Behavior/Mapping/LocaleBehavior.php
@@ -29,4 +29,18 @@ interface LocaleBehavior
      * @param string $locale
      */
     public function setLocale($locale);
+
+    /**
+     * Return the documents original locale.
+     *
+     * @return string
+     */
+    public function getOriginalLocale();
+
+    /**
+     * Sets the document original locale.
+     *
+     * @param string $locale
+     */
+    public function setOriginalLocale($locale);
 }

--- a/lib/DocumentRegistry.php
+++ b/lib/DocumentRegistry.php
@@ -84,7 +84,7 @@ class DocumentRegistry
         $this->documentMap[$oid] = $document;
         $this->documentNodeMap[$oid] = $uuid;
         $this->nodeMap[$node->getIdentifier()] = $node;
-        $this->nodeDocumentMap[sprintf('%s-%s', $node->getIdentifier(), $locale)] = $document;
+        $this->nodeDocumentMap[$this->getNodeLocaleKey($node->getIdentifier(), $locale)] = $document;
         $this->documentLocaleMap[$oid] = $locale;
     }
 
@@ -112,7 +112,7 @@ class DocumentRegistry
      */
     public function hasNode(NodeInterface $node, $locale)
     {
-        return array_key_exists(sprintf('%s-%s', $node->getIdentifier(), $locale), $this->nodeDocumentMap);
+        return array_key_exists($this->getNodeLocaleKey($node->getIdentifier(), $locale), $this->nodeDocumentMap);
     }
 
     /**
@@ -142,7 +142,7 @@ class DocumentRegistry
         $locale = $this->documentLocaleMap[$oid];
 
         unset($this->nodeMap[$nodeIdentifier]);
-        unset($this->nodeDocumentMap[sprintf('%s-%s', $nodeIdentifier, $locale)]);
+        unset($this->nodeDocumentMap[$this->getNodeLocaleKey($nodeIdentifier, $locale)]);
         unset($this->documentMap[$oid]);
         unset($this->documentNodeMap[$oid]);
         unset($this->documentLocaleMap[$oid]);
@@ -212,7 +212,7 @@ class DocumentRegistry
         $identifier = $node->getIdentifier();
         $this->assertNodeExists($identifier);
 
-        return $this->nodeDocumentMap[sprintf('%s-%s', $identifier, $locale)];
+        return $this->nodeDocumentMap[$this->getNodeLocaleKey($node->getIdentifier(), $locale)];
     }
 
     /**
@@ -285,7 +285,7 @@ class DocumentRegistry
             ));
         }
 
-        $documentNodeKey = sprintf('%s-%s', $node->getIdentifier(), $locale);
+        $documentNodeKey = $this->getNodeLocaleKey($node->getIdentifier(), $locale);
         if (array_key_exists($uuid, $this->nodeMap) && array_key_exists($documentNodeKey, $this->nodeDocumentMap)) {
             $registeredDocument = $this->nodeDocumentMap[$documentNodeKey];
 
@@ -342,5 +342,18 @@ class DocumentRegistry
         }
 
         return false;
+    }
+
+    /**
+     * Returns array key for given uuid and locale.
+     *
+     * @param string $uuid
+     * @param string $locale
+     *
+     * @return string
+     */
+    private function getNodeLocaleKey($uuid, $locale)
+    {
+        return sprintf('%s_%s', $uuid, $locale);
     }
 }

--- a/lib/ProxyFactory.php
+++ b/lib/ProxyFactory.php
@@ -78,9 +78,9 @@ class ProxyFactory
     public function createProxyForNode($fromDocument, NodeInterface $targetNode, $options = [])
     {
         // if node is already registered then just return the registered document
-        if ($this->registry->hasNode($targetNode)) {
-            $document = $this->registry->getDocumentForNode($targetNode);
-            $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
+        $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
+        if ($this->registry->hasNode($targetNode, $locale)) {
+            $document = $this->registry->getDocumentForNode($targetNode, $locale);
 
             // If the parent is not loaded in the correct locale, reload it in the correct locale.
             if ($this->registry->getOriginalLocaleForDocument($document) !== $locale) {
@@ -95,10 +95,9 @@ class ProxyFactory
         $initializer = function (LazyLoadingInterface $document, $method, array $parameters, &$initializer) use (
             $fromDocument,
             $targetNode,
-            $options
+            $options,
+            $locale
         ) {
-            $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
-
             $hydrateEvent = new HydrateEvent($targetNode, $locale, $options);
             $hydrateEvent->setDocument($document);
             $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);

--- a/lib/Subscriber/Behavior/Mapping/LocaleSubscriber.php
+++ b/lib/Subscriber/Behavior/Mapping/LocaleSubscriber.php
@@ -39,8 +39,8 @@ class LocaleSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            Events::HYDRATE => ['handleLocale', 250],
-            Events::PERSIST => ['handleLocale', 250],
+            Events::HYDRATE => ['handleLocale', 410],
+            Events::PERSIST => ['handleLocale', 410],
         ];
     }
 
@@ -57,9 +57,8 @@ class LocaleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->getAccessor()->set(
-            'locale',
-            $this->registry->getLocaleForDocument($document)
-        );
+        $locale = $this->registry->getLocaleForDocument($document);
+        $document->setLocale($locale);
+        $document->setOriginalLocale($locale);
     }
 }

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -103,12 +103,11 @@ class RegistratorSubscriber implements EventSubscriberInterface
         }
 
         $node = $event->getNode();
-
-        if (!$this->documentRegistry->hasNode($node)) {
+        if (!$this->documentRegistry->hasNode($node, $event->getLocale())) {
             return;
         }
 
-        $document = $this->documentRegistry->getDocumentForNode($node);
+        $document = $this->documentRegistry->getDocumentForNode($node, $event->getLocale());
 
         $event->setDocument($document);
 
@@ -144,11 +143,7 @@ class RegistratorSubscriber implements EventSubscriberInterface
             (true === $this->documentRegistry->isHydrated($document) && $originalLocale === $locale)
         ) {
             $event->stopPropagation();
-
-            return;
         }
-
-        $this->documentRegistry->updateLocale($document, $locale, $locale);
     }
 
     /**
@@ -238,24 +233,17 @@ class RegistratorSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Register the document and apparently update the locale.
-     *
-     * TODO: Is locale handling already done above?
+     * Register the document.
      *
      * @param AbstractMappingEvent $event
      */
     private function handleRegister(AbstractMappingEvent $event)
     {
-        $document = $event->getDocument();
         $node = $event->getNode();
         $locale = $event->getLocale();
 
-        if ($this->documentRegistry->hasDocument($document)) {
-            $this->documentRegistry->updateLocale($document, $locale);
-
-            return;
+        if (!$this->documentRegistry->hasNode($node, $locale)) {
+            $this->documentRegistry->registerDocument($event->getDocument(), $node, $locale);
         }
-
-        $this->documentRegistry->registerDocument($document, $node, $locale);
     }
 }

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -122,8 +122,7 @@ class RegistratorSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Stop propagation if the document is already loaded in the requested locale,
-     * otherwise reset the document locale to the new locale.
+     * Stop propagation if the document is already loaded in the requested locale.
      *
      * @param HydrateEvent $event
      */

--- a/tests/Functional/Model/FullDocument.php
+++ b/tests/Functional/Model/FullDocument.php
@@ -45,6 +45,7 @@ class FullDocument implements
     protected $status;
     protected $reference;
     protected $locale;
+    protected $originalLocale;
 
     public function __construct()
     {
@@ -128,6 +129,7 @@ class FullDocument implements
      */
     public function setLocale($locale)
     {
+        $this->locale = $locale;
     }
 
     /**
@@ -184,5 +186,15 @@ class FullDocument implements
     public function setReference($reference)
     {
         $this->reference = $reference;
+    }
+
+    public function getOriginalLocale()
+    {
+        return $this->originalLocale;
+    }
+
+    public function setOriginalLocale($originalLocale)
+    {
+        $this->originalLocale = $originalLocale;
     }
 }

--- a/tests/Unit/DocumentRegistryTest.php
+++ b/tests/Unit/DocumentRegistryTest.php
@@ -16,6 +16,9 @@ use Sulu\Component\DocumentManager\DocumentRegistry;
 
 class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var DocumentRegistry
+     */
     private $registry;
 
     public function setUp()
@@ -33,7 +36,7 @@ class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
         $this->assertTrue($this->registry->hasDocument($this->document));
-        $this->assertTrue($this->registry->hasNode($this->node->reveal()));
+        $this->assertTrue($this->registry->hasNode($this->node->reveal(), 'fr'));
     }
 
     /**
@@ -46,7 +49,7 @@ class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
         $this->registry->deregisterDocument($this->document);
         $this->assertFalse($this->registry->hasDocument($this->document));
-        $this->assertFalse($this->registry->hasNode($this->node->reveal()));
+        $this->assertFalse($this->registry->hasNode($this->node->reveal(), 'fr'));
     }
 
     /**
@@ -104,7 +107,7 @@ class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
     public function testGetDocumentForNode()
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
-        $document = $this->registry->getDocumentForNode($this->node->reveal());
+        $document = $this->registry->getDocumentForNode($this->node->reveal(), 'fr');
         $this->assertSame($this->document, $document);
     }
 
@@ -126,17 +129,6 @@ class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
         $this->assertEquals('fr', $this->registry->getLocaleForDocument($this->document));
-    }
-
-    /**
-     * It should update a document locale and store the original locale.
-     */
-    public function testUpdateLocale()
-    {
-        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
-        $this->registry->updateLocale($this->document, 'de', 'fr');
-        $this->assertEquals('de', $this->registry->getLocaleForDocument($this->document));
-        $this->assertEquals('fr', $this->registry->getOriginalLocaleForDocument($this->document));
     }
 
     /**

--- a/tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
@@ -61,6 +61,7 @@ class LocaleSubscriberTest extends \PHPUnit_Framework_TestCase
 class TestLocaleDocument implements LocaleBehavior
 {
     private $locale;
+    private $originalLocale;
 
     public function getLocale()
     {
@@ -70,5 +71,15 @@ class TestLocaleDocument implements LocaleBehavior
     public function setLocale($locale)
     {
         $this->locale = $locale;
+    }
+
+    public function getOriginalLocale()
+    {
+        return $this->originalLocale;
+    }
+
+    public function setOriginalLocale($originalLocale)
+    {
+        $this->originalLocale = $originalLocale;
     }
 }

--- a/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -80,9 +80,10 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('fr');
         $this->hydrateEvent->getOptions()->willReturn([]);
-        $this->registry->hasNode($this->node->reveal())->willReturn(true);
-        $this->registry->getDocumentForNode($this->node->reveal())->willReturn($this->document);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+        $this->registry->getDocumentForNode($this->node->reveal(), 'fr')->willReturn($this->document);
         $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();
+
         $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
     }
 
@@ -100,8 +101,8 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $this->hydrateEvent->stopPropagation()->shouldBeCalled();
-        $this->registry->hasNode($this->node->reveal())->willReturn(true);
-        $this->registry->getDocumentForNode($this->node->reveal())->willReturn($this->document);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+        $this->registry->getDocumentForNode($this->node->reveal(), 'fr')->willReturn($this->document);
         $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();
         $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
     }
@@ -151,30 +152,8 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->getDocument()->willReturn($this->document);
         $this->registry->isHydrated($this->document)->willReturn(true);
         $this->registry->getOriginalLocaleForDocument($this->document)->willReturn($originalLocale);
-        $this->registry->updateLocale($this->document, $locale, $locale)->shouldBeCalled();
         $this->hydrateEvent->stopPropagation()->shouldNotBeCalled();
 
-        $this->subscriber->handleStopPropagationAndResetLocale($this->hydrateEvent->reveal());
-    }
-
-    /**
-     * It should update the locale if the requested locale is different from the loaded locale.
-     */
-    public function testUpdateDocumentLocale()
-    {
-        $locale = 'de';
-        $originalLocale = 'fr';
-
-        $this->hydrateEvent->hasDocument()->willReturn(true);
-        $this->hydrateEvent->getLocale()->willReturn($locale);
-        $this->hydrateEvent->getDocument()->willReturn($this->document);
-        $this->hydrateEvent->getOptions()->willReturn([]);
-        $this->registry->isHydrated($this->document)->willReturn(true);
-
-        $this->registry->getOriginalLocaleForDocument($this->document)->willReturn($originalLocale);
-        $this->hydrateEvent->stopPropagation()->shouldNotBeCalled();
-
-        $this->registry->updateLocale($this->document, $locale, $locale)->shouldBeCalled();
         $this->subscriber->handleStopPropagationAndResetLocale($this->hydrateEvent->reveal());
     }
 
@@ -221,8 +200,9 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testDocumentFromRegistryNoNode()
     {
         $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->getLocale()->willReturn('fr');
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
-        $this->registry->hasNode($this->node->reveal())->willReturn(false);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
         $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
     }
 
@@ -234,7 +214,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->getDocument()->willReturn($this->document);
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('fr');
-        $this->registry->hasDocument($this->document)->willReturn(false);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldBeCalled();
 
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
@@ -249,9 +229,8 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('fr');
 
-        $this->registry->hasDocument($this->document)->willReturn(true);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldNotBeCalled();
-        $this->registry->updateLocale($this->document, 'fr')->shouldBeCalled();
 
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
     }
@@ -264,7 +243,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->persistEvent->getDocument()->willReturn($this->document);
         $this->persistEvent->getNode()->willReturn($this->node->reveal());
         $this->persistEvent->getLocale()->willReturn('fr');
-        $this->registry->hasDocument($this->document)->willReturn(false);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
@@ -280,8 +259,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->persistEvent->getLocale()->willReturn('fr');
 
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldNotBeCalled();
-        $this->registry->updateLocale($this->document, 'fr')->shouldBeCalled();
-        $this->registry->hasDocument($this->document)->willReturn(true);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }


### PR DESCRIPTION
This PR introduces the mandatory locale in the registry. This will fix the problem with "rehydrating" and same document for different locales.
