### PR TITLE
Fixed auto-name subscriber to rename at the very end of persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist 
+
 * 0.6.0 (2016-04-11)
     * ENHANCEMENT #58 Added behavior to save unlocalized timestamps and added json_array mapping type
     * ENHANCEMENT #59 Removed blame subscriber

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "jackalope/jackalope-doctrine-dbal": "~1.2@dev",
         "phpunit/phpunit": "~4.5",
         "monolog/monolog": "~1.0",
-        "phpbench/phpbench": "~0.10"
+        "phpbench/phpbench": "0.10.*"
     },
     "license": "MIT",
     "authors": [

--- a/lib/NameResolver.php
+++ b/lib/NameResolver.php
@@ -27,21 +27,11 @@ class NameResolver
      */
     public function resolveName(NodeInterface $parentNode, $name, $forNode = null)
     {
-        if ($forNode && $parentNode->hasNode($name) && $parentNode->getNode($name) == $forNode) {
-            return $name;
-        }
-
         $index = 0;
         $baseName = $name;
-        do {
-            if ($index > 0) {
-                $name = $baseName . '-' . $index;
-            }
-
-            $hasChild = $parentNode->hasNode($name);
-
-            ++$index;
-        } while ($hasChild);
+        while ($parentNode->hasNode($name) && (!$forNode || $parentNode->getNode($name) !== $forNode)) {
+            $name = $baseName . '-' . ++$index;
+        }
 
         return $name;
     }

--- a/tests/Unit/NameResolverTest.php
+++ b/tests/Unit/NameResolverTest.php
@@ -16,6 +16,21 @@ use Sulu\Component\DocumentManager\NameResolver;
 
 class NameResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NameResolver
+     */
+    private $nameResolver;
+
     public function setUp()
     {
         $this->parentNode = $this->prophesize(NodeInterface::class);
@@ -23,10 +38,7 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->nameResolver = new NameResolver();
     }
 
-    /**
-     * It return the requested name if the parent has no child with the requested name.
-     */
-    public function testResolve()
+    public function testResolveWithNotExistingName()
     {
         $this->parentNode->hasNode('foo')->willReturn(false);
         $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo');
@@ -34,10 +46,7 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $name);
     }
 
-    /**
-     * It should increment the name if the node has a child with the requested name.
-     */
-    public function testResolveIncerement()
+    public function testResolveIncrementWithExistingName()
     {
         $this->parentNode->hasNode('foo')->willReturn(true);
         $this->parentNode->hasNode('foo-1')->willReturn(true);
@@ -47,15 +56,26 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo-2', $name);
     }
 
-    /**
-     * If child exists with requeted name, child is instance of "for node", then its fine.
-     */
-    public function testResolveSame()
+    public function testResolveForNode()
     {
         $this->parentNode->hasNode('foo')->willReturn(true);
         $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
 
         $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $this->node->reveal());
         $this->assertEquals('foo', $name);
+    }
+
+    public function testResolveForNodeWithIncrement()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(true);
+        $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+
+        $this->parentNode->hasNode('foo-1')->willReturn(true);
+        $this->parentNode->getNode('foo-1')->willReturn($node->reveal());
+
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $node->reveal());
+        $this->assertEquals('foo-1', $name);
     }
 }


### PR DESCRIPTION
This PR fixes the `AutoNameSubscriber` to rename the node at the very en of persist.

Newly created issue with phpbench https://github.com/sulu/sulu-document-manager/issues/84
