### PR TITLE
Fixed resolving name for already incremented node names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #86 Fixed resolving name for already incremented node names
     * ENHANCEMENT #58 Added behavior to save unlocalized timestamps and added json_array mapping type
     * ENHANCEMENT #59 Removed blame subscriber
     * Added getAllMetadata() method to MetadataFactoryInterface

--- a/lib/NameResolver.php
+++ b/lib/NameResolver.php
@@ -27,10 +27,6 @@ class NameResolver
      */
     public function resolveName(NodeInterface $parentNode, $name, $forNode = null)
     {
-        if ($forNode && $parentNode->hasNode($name) && $parentNode->getNode($name) == $forNode) {
-            return $name;
-        }
-
         $index = 0;
         $baseName = $name;
         do {
@@ -39,6 +35,10 @@ class NameResolver
             }
 
             $hasChild = $parentNode->hasNode($name);
+
+            if ($forNode && $hasChild && $parentNode->getNode($name) === $forNode) {
+                break;
+            }
 
             ++$index;
         } while ($hasChild);

--- a/tests/Unit/NameResolverTest.php
+++ b/tests/Unit/NameResolverTest.php
@@ -16,6 +16,21 @@ use Sulu\Component\DocumentManager\NameResolver;
 
 class NameResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NameResolver
+     */
+    private $nameResolver;
+
     public function setUp()
     {
         $this->parentNode = $this->prophesize(NodeInterface::class);
@@ -23,10 +38,7 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->nameResolver = new NameResolver();
     }
 
-    /**
-     * It return the requested name if the parent has no child with the requested name.
-     */
-    public function testResolve()
+    public function testResolveWithNotExistingName()
     {
         $this->parentNode->hasNode('foo')->willReturn(false);
         $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo');
@@ -34,10 +46,7 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $name);
     }
 
-    /**
-     * It should increment the name if the node has a child with the requested name.
-     */
-    public function testResolveIncerement()
+    public function testResolveIncrementWithExistingName()
     {
         $this->parentNode->hasNode('foo')->willReturn(true);
         $this->parentNode->hasNode('foo-1')->willReturn(true);
@@ -47,15 +56,26 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo-2', $name);
     }
 
-    /**
-     * If child exists with requeted name, child is instance of "for node", then its fine.
-     */
-    public function testResolveSame()
+    public function testResolveForNode()
     {
         $this->parentNode->hasNode('foo')->willReturn(true);
         $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
 
         $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $this->node->reveal());
         $this->assertEquals('foo', $name);
+    }
+
+    public function testResolveForNodeWithIncrement()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(true);
+        $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+
+        $this->parentNode->hasNode('foo-1')->willReturn(true);
+        $this->parentNode->getNode('foo-1')->willReturn($node->reveal());
+
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $node->reveal());
+        $this->assertEquals('foo-1', $name);
     }
 }


### PR DESCRIPTION
This PR fixes the resolving of node names. When the `NameResolver::resolveName` got passed a `$forNode` which was already suffixed with an increment (e.g. `foo-1`) it didn't recognize it as the same node. That means that saving a page with an already incremented node name always switched between two increments (`foo-1` gets `foo-2` when being saved, and turns back to `foo-1` when saved another time).

This issue made some problems in combination with the publishing, because it moves a node in the session. Since this is neither necessary nor the desired behavior, changing this seems like a valid fix.
