### PR TITLE
Added fallback for empty-node names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #87 Added fallback for empty-node names 
     * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist 
 
 * 0.6.0 (2016-04-11)

--- a/lib/Strategy/MixinStrategy.php
+++ b/lib/Strategy/MixinStrategy.php
@@ -39,11 +39,14 @@ class MixinStrategy implements DocumentStrategyInterface
      */
     public function createNodeForDocument($document, NodeInterface $parentNode, $name)
     {
+        $uuid = UUIDHelper::generateUUID();
+        $name = $name ?: $uuid;
+
         $metadata = $this->metadataFactory->getMetadataForClass(get_class($document));
 
         $node = $parentNode->addNode($name);
         $node->addMixin($metadata->getPhpcrType());
-        $node->setProperty('jcr:uuid', UUIDHelper::generateUUID());
+        $node->setProperty('jcr:uuid', $uuid);
 
         return $node;
     }


### PR DESCRIPTION
This PR adds a fallback to the uuid of the node if the (cleaned) title is empty.

See it in action with https://github.com/sulu/sulu/pull/2400
