### PR TITLE
added required to check to handleChangeParent method of ParentSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * ENHANCEMENT #89 Added auto_rename option to AutoNameSubscriber
     * ENHANCEMENT #89 Extracted LocalizedTitleBehavior from TitleBehavior
+    * BUGFIX      #90 Added missing check in handleChangeParent method of ParentSubscriber
     * BUGFIX      #88 Introduced mandatory locale in document-registry
     * BUGFIX      #85 Fixed get locale for proxy
 

--- a/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
+++ b/lib/Subscriber/Behavior/Mapping/ParentSubscriber.php
@@ -140,6 +140,10 @@ class ParentSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
+        if (!$document instanceof ParentBehavior) {
+            return;
+        }
+
         $node = $this->inspector->getNode($document);
         $parentNode = $event->getParentNode();
 

--- a/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
@@ -18,6 +18,7 @@ use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber;
 
@@ -169,5 +170,15 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->document->setParent(Argument::any())->shouldBeCalled();
 
         $this->subscriber->handleMove($this->moveEvent->reveal());
+    }
+
+    public function testHandleChangeParent()
+    {
+        $persistEvent = $this->prophesize(PersistEvent::class);
+        $persistEvent->getDocument(new \stdClass());
+
+        $this->documentManager->move(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleChangeParent($persistEvent->reveal());
     }
 }


### PR DESCRIPTION
Required for using the `DocumentManager` for restoring routes from history.

This missing check can also harm damage in other situations.
