### PR TITLE
Added replacer to avoid 10e in node-names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #91 Added replacer to avoid 10e in node-names
+
 * 0.8.0 (2016-07-28)
     * FEATURE     #94 Added removeDraft method to DocumentManager
 

--- a/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -199,6 +199,9 @@ class AutoNameSubscriber implements EventSubscriberInterface
 
         $name = $this->slugifier->slugify($title);
 
+        // jackrabbit can not handle node-names which contains a number followed by "e" e.g. 10e
+        $name = preg_replace('((\d+)([eE]))', '$1-$2', $name);
+
         return $this->resolver->resolveName($parentNode, $name, $node, $autoRename);
     }
 

--- a/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -160,6 +160,36 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
+    public function provide10eData()
+    {
+        return [
+            ['10e', '10-e'],
+            ['.10e', '.10-e'],
+            ['-10e', '-10-e'],
+            ['%10e', '%10-e'],
+            ['test-10e-name', 'test-10-e-name'],
+            ['test.10e-name', 'test.10-e-name'],
+            ['test%10e-name', 'test%10-e-name'],
+            ['test-10E-name', 'test-10-E-name'],
+            ['test.10E-name', 'test.10-E-name'],
+            ['test%10E-name', 'test%10-E-name'],
+            ['test10E-name', 'test10-E-name'],
+            ['test-9e-name', 'test-9-e-name'],
+            ['test-500e-name', 'test-500-e-name'],
+        ];
+    }
+
+    /**
+     * It should assign a name based on the documents title.
+     *
+     * @dataProvider provide10eData
+     */
+    public function testAutoName10e($title, $expectedName)
+    {
+        $this->doTestAutoName($title, $expectedName, true, false, $expectedName);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
     /**
      * It should not assign a new name, if the option says it is disabled.
      */
@@ -334,8 +364,10 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->handleRename($this->persistEvent->reveal());
     }
 
-    private function doTestAutoName($title, $expectedName, $create = false, $hasNode = false)
+    private function doTestAutoName($title, $expectedName, $create = false, $hasNode = false, $slugifiedName = null)
     {
+        $slugifiedName = $slugifiedName ?: $title;
+
         $this->persistEvent->getOption('auto_name')->willReturn(true);
         $this->persistEvent->getOption('auto_rename')->willReturn(true);
         $this->persistEvent->hasNode()->willReturn($hasNode);
@@ -346,7 +378,7 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->persistEvent->getDocument()->willReturn($this->document->reveal());
         $this->slugifier->slugify($title)->willReturn($title);
 
-        $this->resolver->resolveName($this->parentNode->reveal(), $title, $node, true)->willReturn($title);
+        $this->resolver->resolveName($this->parentNode->reveal(), $slugifiedName, $node, true)->willReturn($slugifiedName);
         $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
 
         if (!$create) {


### PR DESCRIPTION
This PR avoids `10e` in node names by replacing it. This replaces https://github.com/sulu/sulu/pull/2387 .
