### PR TITLE
Added unpublish method to document manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #93 Use correct default phpcr session
+    * FEATURE     #92 Added unpublish method to DocumentManager
     * ENHANCEMENT #89 Added auto_rename option to AutoNameSubscriber
     * ENHANCEMENT #89 Extracted LocalizedTitleBehavior from TitleBehavior
     * BUGFIX      #90 Added missing check in handleChangeParent method of ParentSubscriber

--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -119,6 +119,15 @@ class DocumentManager implements DocumentManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function unpublish($document, $locale)
+    {
+        $event = new Event\UnpublishEvent($document, $locale);
+        $this->eventDispatcher->dispatch(Events::UNPUBLISH, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function refresh($document)
     {
         $event = new Event\RefreshEvent($document);

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -91,6 +91,14 @@ interface DocumentManagerInterface
     public function publish($document, $locale);
 
     /**
+     * Unpublishes a document from the public workspace.
+     *
+     * @param object $document
+     * @param string $locale
+     */
+    public function unpublish($document, $locale);
+
+    /**
      * Refresh the given document with the persisted state of the node.
      *
      * @param object $document

--- a/lib/Event/UnpublishEvent.php
+++ b/lib/Event/UnpublishEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class UnpublishEvent extends AbstractMappingEvent
+{
+    /**
+     * @param object $document
+     * @param string $locale
+     */
+    public function __construct($document, $locale)
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * TODO Check if should be move to DocumentManager itself
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/lib/Events.php
+++ b/lib/Events.php
@@ -76,6 +76,11 @@ class Events
     const PUBLISH = 'sulu_document_manager.publish';
 
     /**
+     * Fired when the document manager unpublish method is called.
+     */
+    const UNPUBLISH = 'sulu_document_manager.unpublish';
+
+    /**
      * Fired when the document manager requests that are flush to persistent storage happen.
      */
     const FLUSH = 'sulu_document_manager.flush';

--- a/tests/Unit/DocumentManagerTest.php
+++ b/tests/Unit/DocumentManagerTest.php
@@ -27,6 +27,8 @@ use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Event\RefreshEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Query\Query;
@@ -143,6 +145,13 @@ class DocumentManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($subscriber->publish);
     }
 
+    public function testUnpublish()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->unpublish(new \stdClass(), 'de');
+        $this->assertTrue($subscriber->unpublish);
+    }
+
     /**
      * It should issue a refresh event.
      */
@@ -248,6 +257,7 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
     public $queryCreateBuilder = false;
     public $queryExecute = false;
     public $publish = false;
+    public $unpublish = false;
     public $refresh = false;
     public $reorder = false;
 
@@ -278,6 +288,7 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
             Events::REORDER => 'handleReorder',
             Events::CONFIGURE_OPTIONS => 'handleConfigureOptions',
             Events::PUBLISH => 'handlePublish',
+            Events::UNPUBLISH => 'handleUnpublish',
         ];
     }
 
@@ -346,6 +357,11 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
     public function handlePublish(PublishEvent $event)
     {
         $this->publish = true;
+    }
+
+    public function handleUnpublish(UnpublishEvent $event)
+    {
+        $this->unpublish = true;
     }
 
     public function handleRefresh(RefreshEvent $event)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2028 |
| Related issues/PRs | based on #81 |
| License | MIT |
| Documentation PR | TODO |
#### What's in this PR?

This PR adds a unpublish method to the `DocumentManager`.
#### Why?

Because we have to unpublish documents for the drafting feature.
