### PR TITLE
use correct default phpcr session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #93 Use correct default phpcr session
     * ENHANCEMENT #89 Added auto_rename option to AutoNameSubscriber
     * ENHANCEMENT #89 Extracted LocalizedTitleBehavior from TitleBehavior
     * BUGFIX      #90 Added missing check in handleChangeParent method of ParentSubscriber

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -28,7 +28,7 @@
         </service>
 
         <service id="sulu_document_manager.node_manager" class="Sulu\Component\DocumentManager\NodeManager" public="false">
-            <argument type="service" id="doctrine_phpcr.default_session"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
         </service>
 
         <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">

--- a/symfony-di/subscribers.xml
+++ b/symfony-di/subscribers.xml
@@ -91,7 +91,7 @@
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
             <argument type="service" id="sulu_document_manager.event_dispatcher"/>
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>

--- a/tests/Bench/BaseBench.php
+++ b/tests/Bench/BaseBench.php
@@ -45,7 +45,7 @@ abstract class BaseBench
 
     protected function getSession()
     {
-        $session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $session = $this->getContainer()->get('doctrine_phpcr.session');
 
         return $session;
     }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -31,7 +31,7 @@ class Bootstrap
         }
 
         $container = new ContainerBuilder();
-        $container->set('doctrine_phpcr.default_session', self::createSession());
+        $container->set('doctrine_phpcr.session', self::createSession());
         $logger = new Logger('test');
         $logger->pushHandler(new StreamHandler($logDir . '/test.log'));
 

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -32,7 +32,7 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
 
     protected function getSession()
     {
-        return $this->getContainer()->get('doctrine_phpcr.default_session');
+        return $this->getContainer()->get('doctrine_phpcr.session');
     }
 
     protected function getContainer()


### PR DESCRIPTION
`doctrine_phpcr.default_session` is not the default session, but the session actually named "default". `doctrine_phpcr.session` refers to the real default session.
