### PR TITLE
added removeDraft method to DocumentManager

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,3 +11,4 @@ disabled:
     - phpdoc_indent
     - phpdoc_to_comment
     - blankline_after_open_tag
+    - function_declaration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * FEATURE     #94 Added removeDraft method to DocumentManager
+
 * 0.7.0 (2016-07-21)
     * ENHANCEMENT #93 Use correct default phpcr session
     * FEATURE     #92 Added unpublish method to DocumentManager
@@ -12,7 +15,7 @@ CHANGELOG for Sulu
     * BUGFIX      #85 Fixed get locale for proxy
 
 * 0.6.1 (2016-06-01)
-    * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist 
+    * HOTFIX      #83 Fixed auto-name subscriber to rename at the very end of persist
 
 * 0.6.0 (2016-04-11)
     * ENHANCEMENT #58 Added behavior to save unlocalized timestamps and added json_array mapping type

--- a/lib/DocumentManager.php
+++ b/lib/DocumentManager.php
@@ -128,6 +128,15 @@ class DocumentManager implements DocumentManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function removeDraft($document, $locale)
+    {
+        $event = new Event\RemoveDraftEvent($document, $locale);
+        $this->eventDispatcher->dispatch(Events::REMOVE_DRAFT, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function refresh($document)
     {
         $event = new Event\RefreshEvent($document);

--- a/lib/DocumentManagerInterface.php
+++ b/lib/DocumentManagerInterface.php
@@ -60,7 +60,7 @@ interface DocumentManagerInterface
      * Move the PHPCR node to which the document is mapped to be a child of the node at the given path or UUID.
      *
      * @param object $document
-     * @param string $destId The path of the new parent.
+     * @param string $destId The path of the new parent
      */
     public function move($document, $destId);
 
@@ -97,6 +97,14 @@ interface DocumentManagerInterface
      * @param string $locale
      */
     public function unpublish($document, $locale);
+
+    /**
+     * Removes the draft for the given document and reverts it to the values from the public workspace.
+     *
+     * @param $document
+     * @param $locale
+     */
+    public function removeDraft($document, $locale);
 
     /**
      * Refresh the given document with the persisted state of the node.

--- a/lib/Event/RemoveDraftEvent.php
+++ b/lib/Event/RemoveDraftEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class RemoveDraftEvent extends AbstractMappingEvent
+{
+    /**
+     * @param object $document
+     * @param string $locale
+     */
+    public function __construct($document, $locale)
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * TODO Check if should be move to DocumentManager itself
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/lib/Events.php
+++ b/lib/Events.php
@@ -81,6 +81,11 @@ class Events
     const UNPUBLISH = 'sulu_document_manager.unpublish';
 
     /**
+     * Fired when the document discardDraft method is called.
+     */
+    const REMOVE_DRAFT = 'sulu_document_manager.remove_draft';
+
+    /**
      * Fired when the document manager requests that are flush to persistent storage happen.
      */
     const FLUSH = 'sulu_document_manager.flush';

--- a/lib/Subscriber/Core/RegistratorSubscriber.php
+++ b/lib/Subscriber/Core/RegistratorSubscriber.php
@@ -64,6 +64,7 @@ class RegistratorSubscriber implements EventSubscriberInterface
             Events::CLEAR => ['handleClear', 500],
             Events::REORDER => ['handleNodeFromRegistry', 510],
             Events::CONFIGURE_OPTIONS => 'configureOptions',
+            Events::REMOVE_DRAFT => ['handleNodeFromRegistry', 512],
         ];
     }
 

--- a/lib/Subscriber/Phpcr/RefreshSubscriber.php
+++ b/lib/Subscriber/Phpcr/RefreshSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class RefreshSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, DocumentRegistry $documentRegistry)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->documentRegistry = $documentRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REFRESH => 'refreshDocument',
+            Events::REMOVE_DRAFT => ['refreshDocumentForDeleteDraft', -512],
+        ];
+    }
+
+    /**
+     * Refreshes the document when the DocumentManager method for it is called.
+     *
+     * @param RefreshEvent $event
+     */
+    public function refreshDocument(RefreshEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->documentRegistry->getNodeForDocument($document);
+        $locale = $this->documentRegistry->getLocaleForDocument($document);
+
+        // revert/reload the node to the persisted state
+        $node->revert();
+
+        $this->rehydrateDocument($document, $node, $locale);
+    }
+
+    /**
+     * Refreshes the document after a draft have been removed.
+     *
+     * @param RemoveDraftEvent $event
+     */
+    public function refreshDocumentForDeleteDraft(RemoveDraftEvent $event)
+    {
+        $this->rehydrateDocument($event->getDocument(), $event->getNode(), $event->getLocale());
+    }
+
+    /**
+     * Rehydrates the given document from the given node for the given locale.
+     *
+     * @param object $document
+     * @param NodeInterface $node
+     * @param string $locale
+     */
+    private function rehydrateDocument($document, NodeInterface $node, $locale)
+    {
+        $hydrateEvent = new HydrateEvent($node, $locale, ['rehydrate' => true]);
+        $hydrateEvent->setDocument($document);
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+    }
+}

--- a/symfony-di/subscribers.xml
+++ b/symfony-di/subscribers.xml
@@ -112,6 +112,10 @@
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 
+        <service id="sulu_document_manager.subscriber.phpcr.refresh" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RefreshSubscriber">
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
     </services>
-
 </container>

--- a/tests/Unit/DocumentManagerTest.php
+++ b/tests/Unit/DocumentManagerTest.php
@@ -26,6 +26,7 @@ use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 use Sulu\Component\DocumentManager\Event\UnpublishEvent;
@@ -152,6 +153,13 @@ class DocumentManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($subscriber->unpublish);
     }
 
+    public function testRemoveDraft()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->removeDraft(new \stdClass(), 'de');
+        $this->assertTrue($subscriber->removeDraft);
+    }
+
     /**
      * It should issue a refresh event.
      */
@@ -258,6 +266,7 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
     public $queryExecute = false;
     public $publish = false;
     public $unpublish = false;
+    public $removeDraft = false;
     public $refresh = false;
     public $reorder = false;
 
@@ -289,6 +298,7 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
             Events::CONFIGURE_OPTIONS => 'handleConfigureOptions',
             Events::PUBLISH => 'handlePublish',
             Events::UNPUBLISH => 'handleUnpublish',
+            Events::REMOVE_DRAFT => 'handleRemoveDraft',
         ];
     }
 
@@ -362,6 +372,11 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
     public function handleUnpublish(UnpublishEvent $event)
     {
         $this->unpublish = true;
+    }
+
+    public function handleRemoveDraft(RemoveDraftEvent $event)
+    {
+        $this->removeDraft = true;
     }
 
     public function handleRefresh(RefreshEvent $event)

--- a/tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -16,14 +16,11 @@ use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\ClearEvent;
 use Sulu\Component\DocumentManager\Event\CopyEvent;
 use Sulu\Component\DocumentManager\Event\FlushEvent;
-use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\MoveEvent;
 use Sulu\Component\DocumentManager\Event\RefreshEvent;
-use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\NodeHelperInterface;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -45,11 +42,6 @@ class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
      * @var NodeHelperInterface
      */
     private $nodeHelper;
-
-    /**
-     * @var EventDispatcher
-     */
-    private $eventDispatcher;
 
     /**
      * @var MoveEvent
@@ -96,7 +88,6 @@ class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->nodeManager = $this->prophesize(NodeManager::class);
         $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
         $this->nodeHelper = $this->prophesize(NodeHelperInterface::class);
-        $this->eventDispatcher = $this->prophesize(EventDispatcher::class);
 
         $this->moveEvent = $this->prophesize(MoveEvent::class);
         $this->copyEvent = $this->prophesize(CopyEvent::class);
@@ -110,8 +101,7 @@ class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->generalSubscriber = new GeneralSubscriber(
             $this->documentRegistry->reveal(),
             $this->nodeManager->reveal(),
-            $this->nodeHelper->reveal(),
-            $this->eventDispatcher->reveal()
+            $this->nodeHelper->reveal()
         );
     }
 
@@ -167,21 +157,5 @@ class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->nodeManager->save()->shouldBeCalled();
         $this->generalSubscriber->handleFlush($this->flushEvent->reveal());
-    }
-
-    /**
-     * It should refresh a document.
-     */
-    public function testHandleRefresh()
-    {
-        $this->refreshEvent->getDocument()->willReturn($this->document);
-        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
-        $this->node->revert()->shouldBeCalled();
-        $this->documentRegistry->getLocaleForDocument($this->document)->willReturn('fr');
-
-        $event = new HydrateEvent($this->node->reveal(), 'fr');
-        $this->eventDispatcher->dispatch(Events::REFRESH, $event);
-
-        $this->generalSubscriber->handleRefresh($this->refreshEvent->reveal());
     }
 }

--- a/tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\RefreshSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var RefreshSubscriber
+     */
+    private $refreshSubscriber;
+
+    public function setUp()
+    {
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+
+        $this->refreshSubscriber = new RefreshSubscriber(
+            $this->eventDispatcher->reveal(),
+            $this->documentRegistry->reveal()
+        );
+    }
+
+    public function testRefreshDocument()
+    {
+        $document = new \stdClass();
+        $node = $this->prophesize(NodeInterface::class);
+
+        $refreshEvent = $this->prophesize(RefreshEvent::class);
+        $refreshEvent->getDocument()->willReturn($document);
+        $this->documentRegistry->getNodeForDocument($document)->willReturn($node->reveal());
+        $node->revert()->shouldBeCalled();
+        $this->documentRegistry->getLocaleForDocument($document)->willReturn('fr');
+
+        $event = new HydrateEvent($node->reveal(), 'fr');
+        $this->eventDispatcher->dispatch(Events::REFRESH, $event);
+
+        $this->refreshSubscriber->refreshDocument($refreshEvent->reveal());
+    }
+
+    public function testRefreshDocumentForDeleteDraft()
+    {
+        $document = new \stdClass();
+        $node = $this->prophesize(NodeInterface::class);
+
+        $removeDraftEvent = $this->prophesize(RemoveDraftEvent::class);
+        $removeDraftEvent->getNode()->willReturn($node->reveal());
+        $removeDraftEvent->getLocale()->willReturn('de');
+        $removeDraftEvent->getDocument()->willReturn($document);
+
+        $hydrateEvent = new HydrateEvent($node->reveal(), 'de', ['rehydrate' => true]);
+        $hydrateEvent->setDocument($document);
+
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent)->shouldBeCalled();
+
+        $this->refreshSubscriber->refreshDocumentForDeleteDraft($removeDraftEvent->reveal());
+    }
+}


### PR DESCRIPTION
This PR adds a `removeDraft` method to the `DocumentManager`, which will later be used by sulu/sulu to implement the reject draft feature.

Part of the fix for https://github.com/sulu/sulu/issues/2573

Makes https://github.com/sulu/sulu-document-manager/issues/94 even a bit worse...
