### PR TITLE
leave referenceable mixin after publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #99 Leave mix:referencable after publish because of jackrabbit misbehavior
+
 * 0.8.2 (2016-11-24)
     * HOTFIX      #96 Added overwrite option to ExplicitSubscriber
 

--- a/lib/Subscriber/Behavior/Mapping/MixinSubscriber.php
+++ b/lib/Subscriber/Behavior/Mapping/MixinSubscriber.php
@@ -46,12 +46,6 @@ class MixinSubscriber implements EventSubscriberInterface
 
         $metadata = $this->metadataFactory->getMetadataForClass(get_class($document));
 
-        // remove all mixins and add the one defined in the metadata
-        // required because setMixin does not work correctly with jackrabbit
-        $nodeTypes = $node->getMixinNodeTypes();
-        foreach ($nodeTypes as $nodeType) {
-            $node->removeMixin($nodeType->getName());
-        }
         $node->addMixin($metadata->getPhpcrType());
 
         if (!$node->hasProperty('jcr:uuid')) {

--- a/tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
@@ -39,13 +39,8 @@ class MixinSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testSetDocumentMixinsOnNode()
     {
         $event = $this->prophesize(AbstractMappingEvent::class);
-        $mixinNode1 = $this->prophesize(NodeTypeInterface::class);
-        $mixinNode1->getName()->willReturn('phpcr:type-old-1');
-        $mixinNode2 = $this->prophesize(NodeTypeInterface::class);
-        $mixinNode2->getName()->willReturn('phpcr:type-old-2');
         $node = $this->prophesize(NodeInterface::class);
         $node->hasProperty('jcr:uuid')->willReturn(false);
-        $node->getMixinNodeTypes()->willReturn([$mixinNode1->reveal(), $mixinNode2->reveal()]);
         $metadata = $this->prophesize(Metadata::class);
         $metadata->getPhpcrType()->willReturn('phpcr:type');
         $document = new \stdClass();
@@ -55,8 +50,6 @@ class MixinSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getNode()->willReturn($node->reveal());
         $event->getDocument()->willReturn($document);
 
-        $node->removeMixin('phpcr:type-old-1')->shouldBeCalled();
-        $node->removeMixin('phpcr:type-old-2')->shouldBeCalled();
         $node->addMixin('phpcr:type')->shouldBeCalled();
         $node->setProperty('jcr:uuid', Argument::type('string'))->shouldBeCalled();
 


### PR DESCRIPTION
This PR is a workaround for an issue in [jackrabbit](https://github.com/jackalope/jackalope-jackrabbit/issues/137).

If applied it should be possible to publish pages currently being a draft although they have already been linked somewhere else.