### PR TITLE
fixed changed times for both workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #105 Fixed changed times for both workspaces
     * FEATURE     #97  Added versioning functionalities
     * ENHANCEMENT #104 Removed phpcr-odm dependency
     * FEATURE     #101 Added metadata form-type

--- a/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -122,8 +122,7 @@ class TimestampSubscriber implements EventSubscriberInterface
             $document,
             $event->getNode(),
             $event->getAccessor(),
-            $event->getLocale(),
-            new \DateTime()
+            $event->getLocale()
         );
     }
 
@@ -133,15 +132,15 @@ class TimestampSubscriber implements EventSubscriberInterface
      * @param LocalizedTimestampBehavior $document
      * @param NodeInterface $node
      * @param DocumentAccessor $accessor
-     * @param $locale
-     * @param $timestamp
+     * @param string $locale
+     * @param \DateTime|null $timestamp The timestamp to set, will use the documents timestamps if null is provided
      */
     public function setTimestampsOnNode(
         LocalizedTimestampBehavior $document,
         NodeInterface $node,
         DocumentAccessor $accessor,
         $locale,
-        $timestamp
+        $timestamp = null
     ) {
         if (!$document instanceof TimestampBehavior && !$locale) {
             return;
@@ -151,12 +150,14 @@ class TimestampSubscriber implements EventSubscriberInterface
 
         $createdPropertyName = $this->propertyEncoder->encode($encoding, static::CREATED, $locale);
         if (!$node->hasProperty($createdPropertyName)) {
-            $accessor->set(static::CREATED, $timestamp);
-            $node->setProperty($createdPropertyName, $timestamp);
+            $createdTimestamp = $timestamp ?: $document->getCreated();
+            $accessor->set(static::CREATED, $createdTimestamp);
+            $node->setProperty($createdPropertyName, $createdTimestamp);
         }
 
-        $accessor->set(static::CHANGED, $timestamp);
-        $node->setProperty($this->propertyEncoder->encode($encoding, static::CHANGED, $locale), $timestamp);
+        $changedTimestamp = $timestamp ?: $document->getChanged();
+        $accessor->set(static::CHANGED, $changedTimestamp);
+        $node->setProperty($this->propertyEncoder->encode($encoding, static::CHANGED, $locale), $changedTimestamp);
     }
 
     /**

--- a/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
@@ -159,15 +159,21 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getNode()->willReturn($node->reveal());
         $event->getLocale()->willReturn('de');
 
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
         $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
         $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
 
         $node->hasProperty('i18n:de-created')->willReturn(false);
-        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
-        $node->setProperty('i18n:de-created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldBeCalled();
 
-        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
-        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', $changedDate)->shouldBeCalled();
 
         $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
     }
@@ -184,14 +190,20 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getNode()->willReturn($node->reveal());
         $event->getLocale()->willReturn('de');
 
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
         $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
         $node->hasProperty('i18n:de-created')->willReturn(true);
-        $accessor->set('created', Argument::type(\DateTime::class))->shouldNotBeCalled();
-        $node->setProperty('i18n:de-created', Argument::type(\DateTime::class))->shouldNotBeCalled();
+        $accessor->set('created', $createdDate)->shouldNotBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldNotBeCalled();
 
         $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
-        $accessor->set('changed', Argument::type('DateTime'))->shouldBeCalled();
-        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', $changedDate)->shouldBeCalled();
 
         $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
     }
@@ -208,15 +220,21 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getNode()->willReturn($node->reveal());
         $event->getLocale()->willReturn('de');
 
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
         $this->propertyEncoder->encode('system', 'created', 'de')->willReturn('created');
         $this->propertyEncoder->encode('system', 'changed', 'de')->willReturn('changed');
 
         $node->hasProperty('created')->willReturn(false);
-        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
-        $node->setProperty('created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('created', $createdDate)->shouldBeCalled();
 
-        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
-        $node->setProperty('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('changed', $changedDate)->shouldBeCalled();
 
         $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
     }


### PR DESCRIPTION
This PR fixes a bug, which made the `changed` datetime object diverge between the draft and the published workspace. When publishing the datetime from the draft workspace should be used, instead of creating a new object.