### PR TITLE
Update packages to support Symfony 3.2, get rid of deprecated slugifier interface name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - php: 7.0
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
+    - php: 7.1
+      env:
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction"
 
 before_script:
   - composer self-update
@@ -18,7 +21,7 @@ before_script:
   - php bin/testconsole.php jackalope:init:dbal --force
 
 script: 
-  - phpunit
+  - php ./vendor/bin/phpunit
   # run the benchmarks with 1 iteration and 1 rev each to ensure that they work.
   - php ./vendor/bin/phpbench run --progress=dots --iterations=1 --revs=1
 

--- a/composer.json
+++ b/composer.json
@@ -2,20 +2,20 @@
     "name": "sulu/document-manager",
     "description": "Sulu Document Manager",
     "require": {
-        "symfony/event-dispatcher": "~2.8 || ~3.0",
-        "symfony/dependency-injection": "~2.8 || ~3.0",
-        "symfony/config": "~2.8 || ~3.0",
-        "symfony/options-resolver": "~2.8 || ~3.0",
-        "symfony-cmf/slugifier-api": "~1.0",
-        "ocramius/proxy-manager": "~1.0 | ~2.0",
-        "aferrandini/urlizer": "~1.0.0"
+        "symfony/event-dispatcher": "^2.8 || ^3.0",
+        "symfony/dependency-injection": "^2.8 || ^3.0",
+        "symfony/config": "^2.8 || ^3.0",
+        "symfony/options-resolver": "^2.8 || ^3.0",
+        "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
+        "ocramius/proxy-manager": "^1.0 | ^2.0",
+        "aferrandini/urlizer": "^1.0"
     },
     "require-dev": {
-        "jackalope/jackalope-doctrine-dbal": "~1.2.3",
-        "phpunit/phpunit": "^4.5",
+        "jackalope/jackalope-doctrine-dbal": "^1.2.3",
+        "phpunit/phpunit": ">=4.8, <5.4",
         "monolog/monolog": "^1.1",
-        "phpbench/phpbench": "0.10.*",
-        "symfony/phpunit-bridge": "~2.8 || ~3.0"
+        "phpbench/phpbench": "~0.11",
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "license": "MIT",
     "authors": [

--- a/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -23,7 +23,7 @@ use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\NameResolver;
 use Sulu\Component\DocumentManager\NodeManager;
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/tests/Unit/ProxyFactoryTest.php
+++ b/tests/Unit/ProxyFactoryTest.php
@@ -119,9 +119,7 @@ class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
         $options = ['test_option' => 'test'];
 
         $this->node->getParent()->willReturn($this->parentNode->reveal());
-        $this->metadataFactory->getMetadataForPhpcrNode($this->parentNode->reveal())->willReturn(
-            $this->metadata->reveal()
-        );
+        $this->metadataFactory->getMetadataForPhpcrNode($this->parentNode->reveal())->willReturn($this->metadata->reveal());
         $this->metadata->getClass()->willReturn(TestProxyDocumentProxy::class);
 
         $proxy = $this->factory->createProxyForNode($this->document, $this->parentNode->reveal(), $options);
@@ -129,9 +127,9 @@ class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(LazyLoadingInterface::class, $proxy);
 
         $this->dispatcher->dispatch(
-            'sulu_document_manager.hydrate',
+            Events::HYDRATE,
             Argument::that(
-                function ($event) use ($options) {
+                function (HydrateEvent $event) use ($options) {
                     return $event->getOptions() === $options;
                 }
             )

--- a/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -22,7 +22,7 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\NameResolver;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber;
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 
 class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Along with package updates:

- get rid of using deprecated `Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface`
- add closure function signature
- use `Events::HYDRATE` constant instead of hardcoded value