### PR TITLE
updated proxy manager to be compatible with PHP7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu Document Manager
 ===================================
 
 * dev-develop
+    * BUGFIX      #113 Updated ProxyManager to be compatible with PHP 7
     * BUGFIX      #112 Fixed overwrite of exist created date. 
     * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
     * ENHANCEMENT #109 Added metadata to configure remove-live

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/config": "~2.8 || ~3.0",
         "symfony/options-resolver": "~2.8 || ~3.0",
         "symfony-cmf/slugifier-api": "~1.0",
-        "ocramius/proxy-manager": "~1.0",
+        "ocramius/proxy-manager": "~1.0 | ~2.0",
         "aferrandini/urlizer": "~1.0.0"
     },
     "require-dev": {

--- a/tests/Unit/ProxyFactoryTest.php
+++ b/tests/Unit/ProxyFactoryTest.php
@@ -28,6 +28,46 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var Metadata\
+     */
+    private $metadata;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var LazyLoadingGhostFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var TestProxyDocument
+     */
+    private $document;
+
+    /**
      * @var ProxyFactory
      */
     private $factory;
@@ -152,8 +192,10 @@ class TestProxyDocument implements ParentBehavior
 
 class TestProxyDocumentProxy
 {
+    private $title = 'Hello';
+
     public function getTitle()
     {
-        return 'Hello';
+        return $this->title;
     }
 }


### PR DESCRIPTION
Made an update of `ocramius/proxy-manager` to the latest version, in order to be compatible with PHP7.

Merge should wait until it has been tested in a complete setup.