### PR TITLE
Transliterating slugifier to support non-latin characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu Document Manager
 ===================================
 
 * dev-develop
+    * BUGFIX      #113 Updated ProxyManager to be compatible with PHP 7
     * BUGFIX      #112 Fixed overwrite of exist created date. 
     * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
     * ENHANCEMENT #109 Added metadata to configure remove-live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu Document Manager
 ===================================
 
 * dev-develop
+    * BUGFIX      #112 Fixed overwrite of exist created date. 
     * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
     * ENHANCEMENT #109 Added metadata to configure remove-live
     * FEATURE     #107 Added recursive restore to allow also versions of children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu Document Manager
 
 * dev-develop
     * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
+    * ENHANCEMENT #109 Added metadata to configure remove-live
 
 * 0.9.1 (2017-03-16)
     * ENHANCEMENT #107 Added VersionNotFoundException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu Document Manager
 * dev-develop
     * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
     * ENHANCEMENT #109 Added metadata to configure remove-live
+    * FEATURE     #107 Added recursive restore to allow also versions of children
 
 * 0.9.1 (2017-03-16)
     * ENHANCEMENT #107 Added VersionNotFoundException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu Document Manager
 ===================================
 
+* dev-develop
+    * ENHANCEMENT #110 Added node-name-slugifier to centralice additional node name replacer
+
 * 0.9.1 (2017-03-16)
     * ENHANCEMENT #107 Added VersionNotFoundException
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/config": "~2.8 || ~3.0",
         "symfony/options-resolver": "~2.8 || ~3.0",
         "symfony-cmf/slugifier-api": "~1.0",
-        "ocramius/proxy-manager": "~1.0",
+        "ocramius/proxy-manager": "~1.0 | ~2.0",
         "aferrandini/urlizer": "~1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/options-resolver": "~2.8 || ~3.0",
         "symfony-cmf/slugifier-api": "~1.0",
         "ocramius/proxy-manager": "~1.0 | ~2.0",
-        "aferrandini/urlizer": "~1.0.0"
+        "behat/transliterator": "^1.2.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "~1.2.3",

--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -44,6 +44,11 @@ class Metadata
     private $fieldMappings = [];
 
     /**
+     * @var bool
+     */
+    private $syncRemoveLive = true;
+
+    /**
      * Add a field mapping for field with given name, for example.
      *
      * ````
@@ -87,6 +92,8 @@ class Metadata
     }
 
     /**
+     * Returns class.
+     *
      * @return string
      */
     public function getClass()
@@ -95,6 +102,8 @@ class Metadata
     }
 
     /**
+     * Set class.
+     *
      * @param string $class
      */
     public function setClass($class)
@@ -104,6 +113,8 @@ class Metadata
     }
 
     /**
+     * Returns reflection-class.
+     *
      * @return \ReflectionClass
      */
     public function getReflectionClass()
@@ -124,6 +135,8 @@ class Metadata
     }
 
     /**
+     * Returns alias.
+     *
      * @return string
      */
     public function getAlias()
@@ -132,6 +145,8 @@ class Metadata
     }
 
     /**
+     * Set alias.
+     *
      * @param string $alias
      */
     public function setAlias($alias)
@@ -140,6 +155,8 @@ class Metadata
     }
 
     /**
+     * Returns phpcr-type.
+     *
      * @return string
      */
     public function getPhpcrType()
@@ -148,6 +165,8 @@ class Metadata
     }
 
     /**
+     * Set phpcr-type.
+     *
      * @param string $phpcrType
      */
     public function setPhpcrType($phpcrType)
@@ -156,6 +175,8 @@ class Metadata
     }
 
     /**
+     * Returns form-type.
+     *
      * @return string
      */
     public function getFormType()
@@ -164,10 +185,32 @@ class Metadata
     }
 
     /**
+     * Set form-type.
+     *
      * @param string $formType
      */
     public function setFormType($formType)
     {
         $this->formType = $formType;
+    }
+
+    /**
+     * Returns removeLive.
+     *
+     * @return bool
+     */
+    public function getSyncRemoveLive()
+    {
+        return $this->syncRemoveLive;
+    }
+
+    /**
+     * Set removeLive.
+     *
+     * @param bool $syncRemoveLive
+     */
+    public function setSyncRemoveLive($syncRemoveLive)
+    {
+        $this->syncRemoveLive = $syncRemoveLive;
     }
 }

--- a/lib/Slugifier/NodeNameSlugifier.php
+++ b/lib/Slugifier/NodeNameSlugifier.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Slugifier;
+
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+
+/**
+ * Wraps default slugifier and add some additional node-name stuff.
+ */
+class NodeNameSlugifier implements SlugifierInterface
+{
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @param SlugifierInterface $slugifier
+     */
+    public function __construct(SlugifierInterface $slugifier)
+    {
+        $this->slugifier = $slugifier;
+    }
+
+    /**
+     * Slugifies given string to a valid node-name.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    public function slugify($text)
+    {
+        $text = $this->slugifier->slugify($text);
+
+        // jackrabbit can not handle node-names which contains a number followed by "e" e.g. 10e
+        $text = preg_replace('((\d+)([eE]))', '$1-$2', $text);
+
+        return $text;
+    }
+}

--- a/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/lib/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -150,7 +150,7 @@ class TimestampSubscriber implements EventSubscriberInterface
 
         $createdPropertyName = $this->propertyEncoder->encode($encoding, static::CREATED, $locale);
         if (!$node->hasProperty($createdPropertyName)) {
-            $createdTimestamp = $timestamp ?: $document->getCreated();
+            $createdTimestamp = $document->getCreated() ?: $timestamp;
             $accessor->set(static::CREATED, $createdTimestamp);
             $node->setProperty($createdPropertyName, $createdTimestamp);
         }

--- a/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/lib/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -199,9 +199,6 @@ class AutoNameSubscriber implements EventSubscriberInterface
 
         $name = $this->slugifier->slugify($title);
 
-        // jackrabbit can not handle node-names which contains a number followed by "e" e.g. 10e
-        $name = preg_replace('((\d+)([eE]))', '$1-$2', $name);
-
         return $this->resolver->resolveName($parentNode, $name, $node, $autoRename);
     }
 

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -46,6 +46,11 @@
             <argument>Ferrandini\Urlizer::urlize</argument>
         </service>
 
+        <service id="sulu_document_manager.node_name_slugifier"
+                 class="Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier" public="false">
+            <argument type="service" id="sulu_document_manager.slugifier"/>
+        </service>
+
         <service id="sulu_document_manager.namespace_registry" class="Sulu\Component\DocumentManager\NamespaceRegistry" public="false">
             <argument>%sulu_document_manager.namespace_mapping%</argument>
         </service>

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -43,7 +43,7 @@
         </service>
 
         <service id="sulu_document_manager.slugifier" class="Symfony\Cmf\Api\Slugifier\CallbackSlugifier" public="false">
-            <argument>Ferrandini\Urlizer::urlize</argument>
+            <argument>Behat\Transliterator\Transliterator::transliterate</argument>
         </service>
 
         <service id="sulu_document_manager.node_name_slugifier"

--- a/symfony-di/subscribers.xml
+++ b/symfony-di/subscribers.xml
@@ -9,7 +9,7 @@
         <!-- Behavior Subscribers -->
         <service id="sulu_document_manager.subscriber.behavior.auto_name" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber">
             <argument type="service" id="sulu_document_manager.document_registry"/>
-            <argument type="service" id="sulu_document_manager.slugifier"/>
+            <argument type="service" id="sulu_document_manager.node_name_slugifier"/>
             <argument type="service" id="sulu_document_manager.name_resolver"/>
             <argument type="service" id="sulu_document_manager.node_manager"/>
             <tag name="sulu_document_manager.event_subscriber"/>

--- a/tests/Unit/ProxyFactoryTest.php
+++ b/tests/Unit/ProxyFactoryTest.php
@@ -28,6 +28,46 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var Metadata\
+     */
+    private $metadata;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var LazyLoadingGhostFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var TestProxyDocument
+     */
+    private $document;
+
+    /**
      * @var ProxyFactory
      */
     private $factory;
@@ -152,8 +192,10 @@ class TestProxyDocument implements ParentBehavior
 
 class TestProxyDocumentProxy
 {
+    private $title = 'Hello';
+
     public function getTitle()
     {
-        return 'Hello';
+        return $this->title;
     }
 }

--- a/tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
+
+use Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+
+class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @var NodeNameSlugifier
+     */
+    private $nodeNameSlugifier;
+
+    protected function setUp()
+    {
+        $this->slugifier = $this->prophesize(SlugifierInterface::class);
+        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier->reveal());
+    }
+
+    public function testSlugify()
+    {
+        $this->slugifier->slugify('Test article')->willReturn('test-article');
+
+        $this->assertEquals('test-article', $this->nodeNameSlugifier->slugify('Test article'));
+    }
+
+    public function provide10eData()
+    {
+        return [
+            ['10e', '10-e'],
+            ['.10e', '.10-e'],
+            ['-10e', '-10-e'],
+            ['%10e', '%10-e'],
+            ['test-10e-name', 'test-10-e-name'],
+            ['test.10e-name', 'test.10-e-name'],
+            ['test%10e-name', 'test%10-e-name'],
+            ['test-10E-name', 'test-10-E-name'],
+            ['test.10E-name', 'test.10-E-name'],
+            ['test%10E-name', 'test%10-E-name'],
+            ['test10E-name', 'test10-E-name'],
+            ['test-9e-name', 'test-9-e-name'],
+            ['test-500e-name', 'test-500-e-name'],
+        ];
+    }
+
+    /**
+     * @dataProvider provide10eData
+     */
+    public function testSlugify10e($actual, $expected)
+    {
+        $this->slugifier->slugify($actual)->willReturn($actual);
+
+        $this->assertEquals($expected, $this->nodeNameSlugifier->slugify($actual));
+    }
+}

--- a/tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -12,10 +12,17 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
 
 use Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier;
+use Sulu\Component\DocumentManager\Tests\Bootstrap;
 use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+use Symfony\Component\DependencyInjection\Container;
 
 class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Container
+     */
+    private $container;
+
     /**
      * @var SlugifierInterface
      */
@@ -28,33 +35,50 @@ class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->slugifier = $this->prophesize(SlugifierInterface::class);
-        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier->reveal());
+        $this->container = Bootstrap::createContainer();
+        $this->slugifier = $this->container->get('sulu_document_manager.slugifier');
+        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier);
     }
 
     public function testSlugify()
     {
-        $this->slugifier->slugify('Test article')->willReturn('test-article');
-
         $this->assertEquals('test-article', $this->nodeNameSlugifier->slugify('Test article'));
+    }
+
+    public function testSlugifyLatinExtended()
+    {
+        $this->assertEquals('rozszerzony-lacinska', $this->nodeNameSlugifier->slugify('Rozszerzony łacińska'));
+    }
+
+    public function testSlugifyNonLatin()
+    {
+        // ukrainian cyrillic
+        $this->assertEquals('testova-stattia-z-i-yi-ie-g', $this->nodeNameSlugifier->slugify('Тестова стаття з і, ї, є, ґ'));
+        // japanese
+        $this->assertEquals('tesutoji-shi', $this->nodeNameSlugifier->slugify('テスト記事'));
+        // chinese (simplified)
+        $this->assertEquals('ce-shi-wen-zhang', $this->nodeNameSlugifier->slugify('测试文章'));
+        // russian cyrillic
+        $this->assertEquals('testovaia-statia-s-io-y', $this->nodeNameSlugifier->slugify('Тестовая статья с ё, ъ, ы'));
     }
 
     public function provide10eData()
     {
         return [
             ['10e', '10-e'],
-            ['.10e', '.10-e'],
-            ['-10e', '-10-e'],
-            ['%10e', '%10-e'],
+            ['.10e', '10-e'],
+            ['-10e', '10-e'],
+            ['%10e', '10-e'],
             ['test-10e-name', 'test-10-e-name'],
-            ['test.10e-name', 'test.10-e-name'],
-            ['test%10e-name', 'test%10-e-name'],
-            ['test-10E-name', 'test-10-E-name'],
-            ['test.10E-name', 'test.10-E-name'],
-            ['test%10E-name', 'test%10-E-name'],
-            ['test10E-name', 'test10-E-name'],
+            ['test.10e-name', 'test-10-e-name'],
+            ['test%10e-name', 'test-10-e-name'],
+            ['test-10E-name', 'test-10-e-name'],
+            ['test.10E-name', 'test-10-e-name'],
+            ['test%10E-name', 'test-10-e-name'],
+            ['test10E-name', 'test10-e-name'],
             ['test-9e-name', 'test-9-e-name'],
             ['test-500e-name', 'test-500-e-name'],
+            ['тестова-500e-назва', 'testova-500-e-nazva'],
         ];
     }
 
@@ -63,8 +87,6 @@ class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
      */
     public function testSlugify10e($actual, $expected)
     {
-        $this->slugifier->slugify($actual)->willReturn($actual);
-
         $this->assertEquals($expected, $this->nodeNameSlugifier->slugify($actual));
     }
 }

--- a/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
@@ -73,6 +73,33 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
     }
 
+    public function testSetTimestampsOnNodeForPersistCreatedWhenSet()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $createdDate = new \DateTime('2013-01-12');
+        $document->getCreated()->willReturn($createdDate);
+        $node->hasProperty('i18n:de-created')->willReturn();
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldBeCalled();
+
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
     public function testSetTimestampsOnNodeForPersistChanged()
     {
         $event = $this->prophesize(PersistEvent::class);

--- a/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -160,36 +160,6 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
-    public function provide10eData()
-    {
-        return [
-            ['10e', '10-e'],
-            ['.10e', '.10-e'],
-            ['-10e', '-10-e'],
-            ['%10e', '%10-e'],
-            ['test-10e-name', 'test-10-e-name'],
-            ['test.10e-name', 'test.10-e-name'],
-            ['test%10e-name', 'test%10-e-name'],
-            ['test-10E-name', 'test-10-E-name'],
-            ['test.10E-name', 'test.10-E-name'],
-            ['test%10E-name', 'test%10-E-name'],
-            ['test10E-name', 'test10-E-name'],
-            ['test-9e-name', 'test-9-e-name'],
-            ['test-500e-name', 'test-500-e-name'],
-        ];
-    }
-
-    /**
-     * It should assign a name based on the documents title.
-     *
-     * @dataProvider provide10eData
-     */
-    public function testAutoName10e($title, $expectedName)
-    {
-        $this->doTestAutoName($title, $expectedName, true, false, $expectedName);
-        $this->subscriber->handlePersist($this->persistEvent->reveal());
-    }
-
     /**
      * It should not assign a new name, if the option says it is disabled.
      */

--- a/tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
+++ b/tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
@@ -14,8 +14,10 @@ namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
 use Jackalope\Version\Version as JackalopeVersion;
 use Jackalope\Workspace;
 use PHPCR\NodeInterface;
+use PHPCR\NodeType\NodeDefinitionInterface;
 use PHPCR\PropertyInterface;
 use PHPCR\SessionInterface;
+use PHPCR\Version\OnParentVersionAction;
 use PHPCR\Version\VersionHistoryInterface;
 use PHPCR\Version\VersionInterface;
 use PHPCR\Version\VersionManagerInterface;
@@ -343,6 +345,7 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
         $property3 = $this->prophesize(PropertyInterface::class);
         $property3->getName()->willReturn('jcr:uuid');
         $node->getProperties()->willReturn([$property1->reveal(), $property2->reveal(), $property3->reveal()]);
+        $node->getNodes()->willReturn([]);
 
         $property1->remove()->shouldBeCalled();
         $property2->remove()->shouldBeCalled();
@@ -351,6 +354,7 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
         $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
 
+        $frozenNode->getNodes()->willReturn([]);
         $frozenNode->getPropertiesValues()->willReturn([
             'i18n:de-test' => 'Title',
             'non-translatable-test' => 'Article',
@@ -369,6 +373,135 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
         $node->setProperty('i18n:de-test', 'Title')->shouldBeCalled();
         $node->setProperty('non-translatable-test', 'Article')->shouldBeCalled();
         $node->setProperty('jcr:uuid', 'asdf')->shouldNotBeCalled();
+
+        $this->versionSubscriber->restoreProperties($event->reveal());
+    }
+
+    public function testRestoreChildren()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $document = $this->prophesize(VersionBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $versionHistory = $this->prophesize(VersionHistoryInterface::class);
+        $version = $this->prophesize(JackalopeVersion::class);
+        $frozenNode = $this->prophesize(NodeInterface::class);
+
+        $node->getPath()->willReturn('/node');
+        $node->getProperties()->willReturn([]);
+        $node->hasNode('child1')->willReturn(false);
+        $node->hasNode('child2')->willReturn(true);
+        $node->hasNode('child3')->willReturn(true);
+
+        $definition = $this->prophesize(NodeDefinitionInterface::class);
+        $definition->getOnParentVersion()->willReturn(OnParentVersionAction::COPY);
+
+        $newChild2Node = $this->prophesize(NodeInterface::class);
+        $newChild2Node->getName()->willReturn('child2');
+        $newChild2Node->getProperties()->willReturn([]);
+        $newChild2Node->getNodes()->willReturn([]);
+        $newChild2Node->getDefinition()->willReturn($definition->reveal());
+
+        $newChild3Node = $this->prophesize(NodeInterface::class);
+        $newChild3Node->getName()->willReturn('child3');
+        $newChild3Node->getDefinition()->willReturn($definition->reveal());
+        $newChild3Node->remove()->shouldBeCalled();
+
+        $newChild1Node = $this->prophesize(NodeInterface::class);
+        $newChild1Node->getName()->willReturn('child1');
+        $newChild1Node->setMixins(['jcr:referencable'])->shouldBeCalled();
+        $newChild1Node->getProperties()->willReturn([]);
+        $newChild1Node->getNodes()->willReturn([]);
+        $newChild1Node->getDefinition()->willReturn($definition->reveal());
+        $node->addNode('child1')->will(
+            function () use ($node, $newChild1Node, $newChild2Node, $newChild3Node) {
+                $node->getNode('child1')->willReturn($newChild1Node->reveal());
+                $node->getNodes()->willReturn(
+                    [$newChild1Node->reveal(), $newChild2Node->reveal(), $newChild3Node->reveal()]
+                );
+
+                return $newChild1Node->reveal();
+            }
+        );
+
+        $node->getNode('child2')->willReturn($newChild2Node->reveal());
+        $node->getNode('child3')->willReturn($newChild3Node->reveal());
+        $node->getNodes()->willReturn([$newChild2Node->reveal(), $newChild3Node->reveal()]);
+
+        $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
+        $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
+
+        $child1 = $this->prophesize(NodeInterface::class);
+        $child1->getName()->willReturn('child1');
+        $child1->getPropertyValueWithDefault('jcr:frozenMixinTypes', [])->willReturn(['jcr:referencable']);
+        $child1->getPropertiesValues()->willReturn([]);
+        $child1->getNodes()->willReturn([]);
+        $child2 = $this->prophesize(NodeInterface::class);
+        $child2->getName()->willReturn('child2');
+        $child2->getPropertiesValues()->willReturn([]);
+        $child2->getNodes()->willReturn([]);
+
+        $frozenNode->getNodes()->willReturn([$child1->reveal(), $child2->reveal()]);
+        $frozenNode->getPropertiesValues()->willReturn([]);
+        $frozenNode->hasNode('child1')->willReturn(true);
+        $frozenNode->hasNode('child2')->willReturn(true);
+        $frozenNode->hasNode('child3')->willReturn(false);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getVersion()->willReturn('1.0');
+        $event->getLocale()->willReturn('de');
+
+        $this->versionManager->getVersionHistory('/node')->willReturn($versionHistory->reveal());
+        $versionHistory->getVersion('1.0')->willReturn($version->reveal());
+        $version->getFrozenNode()->willReturn($frozenNode->reveal());
+
+        $this->versionSubscriber->restoreProperties($event->reveal());
+    }
+
+    public function testRestoreIgnoreChildren()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $document = $this->prophesize(VersionBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $versionHistory = $this->prophesize(VersionHistoryInterface::class);
+        $version = $this->prophesize(JackalopeVersion::class);
+        $frozenNode = $this->prophesize(NodeInterface::class);
+
+        $node->getPath()->willReturn('/node');
+        $node->getProperties()->willReturn([]);
+        $node->hasNode('child')->willReturn(true);
+
+        $definition = $this->prophesize(NodeDefinitionInterface::class);
+        $definition->getOnParentVersion()->willReturn(OnParentVersionAction::IGNORE);
+
+        $childNode = $this->prophesize(NodeInterface::class);
+        $childNode->getName()->willReturn('child');
+        $childNode->getProperties()->willReturn([]);
+        $childNode->getNodes()->willReturn([]);
+        $childNode->getDefinition()->willReturn($definition->reveal());
+
+        $node->getNode('child')->willReturn($childNode->reveal());
+        $node->getNodes()->willReturn([$childNode->reveal()]);
+
+        $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
+        $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
+
+        $frozenNode->getNodes()->willReturn([]);
+        $frozenNode->getPropertiesValues()->willReturn([]);
+        $frozenNode->hasNode(Argument::type('string'))->willReturn(false);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getVersion()->willReturn('1.0');
+        $event->getLocale()->willReturn('de');
+
+        $this->versionManager->getVersionHistory('/node')->willReturn($versionHistory->reveal());
+        $versionHistory->getVersion('1.0')->willReturn($version->reveal());
+        $version->getFrozenNode()->willReturn($frozenNode->reveal());
+
+        // the child-node should not be touched
+        $childNode->remove()->shouldNotBeCalled();
+        $childNode->setProperty(Argument::cetera())->shouldNotBeCalled();
 
         $this->versionSubscriber->restoreProperties($event->reveal());
     }


### PR DESCRIPTION
This is done in favor of sulu/sulu#3367
* use [behat/transliterator](https://packagist.org/packages/behat/transliterator) instead of [aferrandini/urlizer](https://packagist.org/packages/aferrandini/urlizer) - they are very similar and have same api (or at least very similar, anyway both have `urlize()`/`transliterate()`), but `behat/transliterator` is updated to a more recent version of [Text::Unidecode](http://search.cpan.org/~sburke/Text-Unidecode-1.27/lib/Text/Unidecode.pm) data, which both are based upon
* extend unit test to unhide the undergoing problem