### PR TITLE
Transliterating slugifier to support non-latin characters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/options-resolver": "~2.8 || ~3.0",
         "symfony-cmf/slugifier-api": "~1.0",
         "ocramius/proxy-manager": "~1.0 | ~2.0",
-        "aferrandini/urlizer": "~1.0.0"
+        "behat/transliterator": "^1.2.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "~1.2.3",

--- a/symfony-di/core.xml
+++ b/symfony-di/core.xml
@@ -43,7 +43,7 @@
         </service>
 
         <service id="sulu_document_manager.slugifier" class="Symfony\Cmf\Api\Slugifier\CallbackSlugifier" public="false">
-            <argument>Ferrandini\Urlizer::urlize</argument>
+            <argument>Behat\Transliterator\Transliterator::transliterate</argument>
         </service>
 
         <service id="sulu_document_manager.node_name_slugifier"

--- a/tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -12,10 +12,17 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
 
 use Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier;
+use Sulu\Component\DocumentManager\Tests\Bootstrap;
 use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+use Symfony\Component\DependencyInjection\Container;
 
 class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Container
+     */
+    private $container;
+
     /**
      * @var SlugifierInterface
      */
@@ -28,33 +35,50 @@ class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->slugifier = $this->prophesize(SlugifierInterface::class);
-        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier->reveal());
+        $this->container = Bootstrap::createContainer();
+        $this->slugifier = $this->container->get('sulu_document_manager.slugifier');
+        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier);
     }
 
     public function testSlugify()
     {
-        $this->slugifier->slugify('Test article')->willReturn('test-article');
-
         $this->assertEquals('test-article', $this->nodeNameSlugifier->slugify('Test article'));
+    }
+
+    public function testSlugifyLatinExtended()
+    {
+        $this->assertEquals('rozszerzony-lacinska', $this->nodeNameSlugifier->slugify('Rozszerzony łacińska'));
+    }
+
+    public function testSlugifyNonLatin()
+    {
+        // ukrainian cyrillic
+        $this->assertEquals('testova-stattia-z-i-yi-ie-g', $this->nodeNameSlugifier->slugify('Тестова стаття з і, ї, є, ґ'));
+        // japanese
+        $this->assertEquals('tesutoji-shi', $this->nodeNameSlugifier->slugify('テスト記事'));
+        // chinese (simplified)
+        $this->assertEquals('ce-shi-wen-zhang', $this->nodeNameSlugifier->slugify('测试文章'));
+        // russian cyrillic
+        $this->assertEquals('testovaia-statia-s-io-y', $this->nodeNameSlugifier->slugify('Тестовая статья с ё, ъ, ы'));
     }
 
     public function provide10eData()
     {
         return [
             ['10e', '10-e'],
-            ['.10e', '.10-e'],
-            ['-10e', '-10-e'],
-            ['%10e', '%10-e'],
+            ['.10e', '10-e'],
+            ['-10e', '10-e'],
+            ['%10e', '10-e'],
             ['test-10e-name', 'test-10-e-name'],
-            ['test.10e-name', 'test.10-e-name'],
-            ['test%10e-name', 'test%10-e-name'],
-            ['test-10E-name', 'test-10-E-name'],
-            ['test.10E-name', 'test.10-E-name'],
-            ['test%10E-name', 'test%10-E-name'],
-            ['test10E-name', 'test10-E-name'],
+            ['test.10e-name', 'test-10-e-name'],
+            ['test%10e-name', 'test-10-e-name'],
+            ['test-10E-name', 'test-10-e-name'],
+            ['test.10E-name', 'test-10-e-name'],
+            ['test%10E-name', 'test-10-e-name'],
+            ['test10E-name', 'test10-e-name'],
             ['test-9e-name', 'test-9-e-name'],
             ['test-500e-name', 'test-500-e-name'],
+            ['тестова-500e-назва', 'testova-500-e-nazva'],
         ];
     }
 
@@ -63,8 +87,6 @@ class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
      */
     public function testSlugify10e($actual, $expected)
     {
-        $this->slugifier->slugify($actual)->willReturn($actual);
-
         $this->assertEquals($expected, $this->nodeNameSlugifier->slugify($actual));
     }
 }

--- a/tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -16,7 +16,6 @@ use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Event\CreateEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Metadata;
-use Sulu\Component\DocumentManager\MetadataFactory;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber;
 

--- a/tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -18,11 +18,9 @@ use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\Metadata;
-use Sulu\Component\DocumentManager\MetadataFactory;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class FindSubscriberTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
This is done in favor of sulu/sulu#3367
* use [behat/transliterator](https://packagist.org/packages/behat/transliterator) instead of [aferrandini/urlizer](https://packagist.org/packages/aferrandini/urlizer) - they are very similar and have same api (or at least very similar, anyway both have `urlize()`/`transliterate()`), but `behat/transliterator` is updated to a more recent version of [Text::Unidecode](http://search.cpan.org/~sburke/Text-Unidecode-1.27/lib/Text/Unidecode.pm) data, which both are based upon
* extend unit test to unhide the undergoing problem
* add basic tests for extended latin and non-latin symbols (ukrainian cyrillic, japanese, chinese (simplified) and russian cyrillic)